### PR TITLE
docs: prepare daily impulse feature for later integration

### DIFF
--- a/docs/CODEX_CLAUDE_TAGESIMPULSE_HANDOFF.md
+++ b/docs/CODEX_CLAUDE_TAGESIMPULSE_HANDOFF.md
@@ -1,0 +1,164 @@
+# Claude Handoff — Tagesimpulse
+
+Bitte uebernimm die spaetere technische Integration des Tagesimpuls-Features fuer PBP.
+
+## Zuerst lesen
+
+1. `AGENTS.md`
+2. `docs/TAGESIMPULSE_SEED.md`
+3. `docs/TAGESIMPULSE_IMPLEMENTIERUNGSPLAN.md`
+4. `src/bewerbungs_assistent/services/workspace_service.py`
+5. `src/bewerbungs_assistent/dashboard.py`
+6. `frontend/src/pages/DashboardPage.jsx`
+7. `frontend/src/pages/SettingsPage.jsx`
+
+## Ziel
+
+PBP soll optional einen kleinen, taeglichen Impuls im Dashboard anzeigen.
+
+Das Feature soll:
+- motivieren, ohne kitschig zu werden
+- zur Jobsuche passen
+- taeglich stabil sein
+- in den Einstellungen deaktivierbar sein
+- spaeter leicht erweitert werden koennen
+
+## Bereits vorbereitet
+
+- Seed-Sammlung mit 140 Originaltexten:
+  - `docs/TAGESIMPULSE_SEED.md`
+- technischer und produktseitiger Plan:
+  - `docs/TAGESIMPULSE_IMPLEMENTIERUNGSPLAN.md`
+
+## Empfohlener technischer Schnitt
+
+### 1. Content-Datei
+
+Lege eine maschinenlesbare Datei an, z. B.:
+- `src/bewerbungs_assistent/content/tagesimpulse.json`
+
+Uebernimm die Seed-Texte aus `docs/TAGESIMPULSE_SEED.md` mit:
+- `id`
+- `text`
+- `tags`
+- `contexts`
+- optional `tones`
+
+### 2. Service
+
+Neue Datei:
+- `src/bewerbungs_assistent/services/daily_impulse_service.py`
+
+Der Service soll:
+- Kontext bestimmen
+- passende Impulse filtern
+- taeglich stabile Auswahl treffen
+- deaktivierte Anzeige respektieren
+
+### 3. API
+
+Bevorzugt neuer Endpoint:
+- `GET /api/daily-impulse`
+
+Rueckgabeform:
+
+```json
+{
+  "enabled": true,
+  "context": "search_refresh",
+  "impulse": {
+    "id": "impuls_052",
+    "title": "Heute fuer dich",
+    "text": "Heute musst du nicht den perfekten Job finden. Nur den naechsten guten Treffer.",
+    "tags": ["jobsuche", "alltag"]
+  }
+}
+```
+
+### 4. Settings
+
+Neue User-Preference:
+- `daily_impulse_enabled`
+
+Default:
+- `true`
+
+UI:
+- kleiner Toggle in `SettingsPage.jsx`
+- Text: `Tagesimpuls im Dashboard anzeigen`
+
+### 5. Dashboard
+
+In `DashboardPage.jsx`:
+- kleine Card oder Banner
+- unaufdringlich
+- idealerweise zwischen Header/Workspace und Metriken
+
+## Kontextlogik fuer V1
+
+Verwende nur einfache, bereits vorhandene Signale:
+
+- `onboarding`
+- `profile_building`
+- `sources_missing`
+- `search_refresh`
+- `jobs_ready`
+- `follow_up_due`
+- `weekend`
+- `default`
+
+Wochenende:
+- Samstag/Sonntag direkt ueber Datum
+
+Feiertage:
+- optional spaeter, nicht noetig fuer den ersten Einbau
+
+## Prioritaet bei mehreren Kontexten
+
+1. `weekend`
+2. `follow_up_due`
+3. `jobs_ready`
+4. `search_refresh`
+5. `sources_missing`
+6. `profile_building`
+7. `onboarding`
+8. `default`
+
+## Wichtige Produktregeln
+
+- Kein grosses Gamification-System
+- Keine KI-Livegenerierung fuer V1
+- Nicht zu gross und nicht zu laut im Dashboard
+- Keine zufaellige Rotation bei jedem Refresh
+- Pro Tag stabil
+
+## Tests
+
+Bitte mindestens ergaenzen:
+
+- `tests/test_daily_impulse_service.py`
+- API-Test in `tests/test_dashboard.py`
+- Browser-Smoke fuer Sichtbarkeit/Toggle in `tests/test_dashboard_browser.py`
+
+## Akzeptanzkriterien
+
+- Dashboard zeigt einen Tagesimpuls
+- derselbe Tag zeigt denselben Impuls
+- Toggle blendet das Feature sauber aus
+- keine Beeintraechtigung der bestehenden Workspace-Guidance
+- Tests laufen gruen
+
+## Nicht tun
+
+- Keine riesige Refactor-Welle im Dashboard
+- Nicht 365 Texte erzwingen
+- Keine aggressive Animation
+- Kein Pop-up, kein Modal, kein Alert
+
+## Zielbild
+
+Am Ende soll es sich anfuehlen wie:
+- kleine menschliche Begleitung
+- passend zu PBP
+- nicht kitschig
+- nicht stoerend

--- a/docs/TAGESIMPULSE_IMPLEMENTIERUNGSPLAN.md
+++ b/docs/TAGESIMPULSE_IMPLEMENTIERUNGSPLAN.md
@@ -1,0 +1,382 @@
+# PBP Tagesimpulse — Implementierungsplan
+
+Stand: 2026-03-21
+
+## Ziel
+
+PBP soll optional einen kleinen, taeglichen Impuls im Dashboard anzeigen.
+
+Der Impuls soll:
+- motivieren, ohne kitschig zu wirken
+- die Rueckkehr ins PBP positiv bestaerken
+- je nach Situation leicht anders klingen
+- abschaltbar sein
+- bei mehrfachem Oeffnen am selben Tag stabil bleiben
+
+Das Feature ist bewusst **kein** grosses Gamification-System.
+Es ist ein kleines, menschliches Zusatzsignal.
+
+## Produktidee in einem Satz
+
+PBP zeigt beim Oeffnen des Dashboards einen kurzen, passenden Tagesimpuls, der zur aktuellen Bewerbungsphase, zum Wochentag und zum Arbeitsstand passt.
+
+## Empfohlener Name
+
+Nicht:
+- Motivationsspruch
+- Quote des Tages
+
+Besser:
+- Tagesimpuls
+- Heute fuer dich
+- Kleiner Kompass
+
+Im Plan wird der neutrale Arbeitsname `Tagesimpuls` verwendet.
+
+## Scope fuer die erste Version
+
+### Enthalten
+
+- kleine Impuls-Karte im Dashboard
+- taegliche Auswahl aus kuratierter Sammlung
+- gleiche Anzeige fuer den ganzen Kalendertag
+- einfache Kontextlogik
+- Einstellung an/aus
+- spaeter leicht erweiterbar
+
+### Nicht enthalten
+
+- KI-generierte Live-Sprueche
+- komplexe Personalisierung pro Nutzerstil
+- eigene Historienseite fuer alle bisherigen Impulse
+- Belohnungssystem, Punkte, Streaks, Badges
+
+## Warum das in PBP passt
+
+- Jobsuche ist nicht nur Organisation, sondern auch Ausdauer und Selbstregulation.
+- PBP ist bereits Begleiter, nicht nur Datenverwaltung.
+- Das Feature kann die Rueckkehr ins Tool weicher machen, ohne vom Kernprodukt abzulenken.
+
+## Produkt-Risiken
+
+### 1. Kitsch-Risiko
+
+Wenn der Ton zu kalenderhaft wird, verliert das Feature sofort an Wert.
+
+### 2. Nerven-Risiko
+
+Wenn der Impuls zu gross, zu bunt oder zu dominant ist, wird er schnell weggeschaltet.
+
+### 3. Ton-Risiko
+
+Humor und leichter Sarkasmus koennen gut sein, duerfen aber in Rueckschlag-Momenten nicht zynisch kippen.
+
+### 4. Wartungs-Risiko
+
+Der eigentliche Aufwand ist eher Content-Pflege als Code.
+
+## Empfohlene UX
+
+### Platzierung
+
+Dashboard-Seite, im oberen Bereich, aber unterhalb der wichtigsten Arbeits-Guidance.
+
+Empfehlung:
+- unter Workspace-Guidance
+- oberhalb der Metriken oder zwischen Header und Metriken
+
+### Darstellung
+
+- kleine Karte
+- 1 kurzer Titel, z. B. `Heute fuer dich`
+- 1 Spruch/Impuls
+- optional 1 kleines Kontextlabel wie `Ruhig`, `Dranbleiben`, `Heute reicht ein Schritt`
+
+### Verhalten
+
+- pro Kalendertag stabil
+- kein automatisches Rotieren im laufenden Tag
+- unaufdringlich
+
+### Interaktionen
+
+Fuer V1:
+- nur anzeigen
+- in Einstellungen abschaltbar
+
+Optional spaeter:
+- `Heute ausblenden`
+- `Anderen Impuls anzeigen`
+- `Mehr Humor / Mehr Ruhe / Mehr Ernst`
+
+## Datenmodell
+
+Empfehlung fuer V1:
+
+Datei im Repo, z. B.
+- `src/bewerbungs_assistent/content/tagesimpulse.json`
+
+Beispielstruktur:
+
+```json
+[
+  {
+    "id": "impuls_001",
+    "text": "Heute musst du nicht alles loesen. Du musst nur wieder anfangen.",
+    "tags": ["ermutigend", "alltag"],
+    "tones": ["warm"],
+    "contexts": ["default", "onboarding", "profile_building"],
+    "weekend_ok": true,
+    "holiday_ok": true,
+    "weight": 1
+  }
+]
+```
+
+## Erste Kontextlogik
+
+PBP muss nicht erraten, was los ist. Vieles ist schon im System vorhanden.
+
+### Bereits nutzbare Signale
+
+Aus `workspace_service.py` / Dashboard-Status:
+- kein Profil vorhanden
+- Profil unvollstaendig
+- keine Quellen aktiv
+- Jobsuche nie/veraltet/dringend
+- Jobs vorhanden, aber noch keine Bewerbungen
+- Follow-up ueberfaellig
+
+Aus Datum:
+- Wochenende
+- spaeter Feiertag
+
+Aus Bewerbungslage, optional fuer V2:
+- juengste Bewerbung wurde abgelehnt
+- Interview bald
+
+### Empfohlene Kontexte fuer V1
+
+- `default`
+- `onboarding`
+- `profile_building`
+- `sources_missing`
+- `search_refresh`
+- `jobs_ready`
+- `follow_up_due`
+- `weekend`
+- `holiday`
+
+### Kontext-Prioritaet
+
+Wenn mehrere Kontexte gleichzeitig gelten:
+
+1. `holiday`
+2. `weekend`
+3. `follow_up_due`
+4. `jobs_ready`
+5. `search_refresh`
+6. `sources_missing`
+7. `profile_building`
+8. `onboarding`
+9. `default`
+
+## Technischer Aufbau
+
+### Backend
+
+Neue Datei:
+- `src/bewerbungs_assistent/services/daily_impulse_service.py`
+
+Aufgaben:
+- Impuls-Daten laden
+- Kontext aus Workspace/Zeit bestimmen
+- tagesstabile Auswahl treffen
+- deaktivierte Anzeige respektieren
+
+Empfohlene API:
+- `get_daily_impulse(profile, workspace_summary, today=None) -> dict | None`
+
+Rueckgabe:
+
+```python
+{
+    "id": "impuls_042",
+    "title": "Heute fuer dich",
+    "text": "Heute reicht auch: Quellen checken, Suche anstossen, weitersehen.",
+    "tags": ["jobsuche", "alltag"],
+    "context": "search_refresh",
+}
+```
+
+### Dashboard-API
+
+Option A:
+- in `/api/workspace-summary` integrieren
+
+Option B, empfohlen:
+- neuer Endpoint `/api/daily-impulse`
+
+Warum Option B:
+- sauber getrennt
+- leichter testbar
+- spaeter leichter ausbaubar
+
+### Settings
+
+Neue User-Preference:
+- `daily_impulse_enabled`
+
+Optional spaeter:
+- `daily_impulse_tone`
+
+V1:
+- default `true`
+
+### Frontend
+
+Dashboard:
+- neue kleine `DailyImpulseCard`
+
+Settings:
+- einfacher Toggle:
+  - `Tagesimpuls im Dashboard anzeigen`
+
+## Auswahl-Logik
+
+### Wichtig
+
+Nicht einfach `today.day_of_year % len(list)`.
+
+Besser:
+- erst passende Kandidaten nach Kontext filtern
+- dann aus diesen stabil fuer den Tag auswaehlen
+
+Beispiel:
+- Seed aus `YYYY-MM-DD + context`
+- daraus Index in Kandidatenliste
+
+Vorteile:
+- pro Tag stabil
+- je Kontext anders
+- Sammlung spaeter erweiterbar
+
+## Feiertage
+
+### V1 Empfehlung
+
+Feiertage noch nicht perfekt loesen, sondern vorbereitet bauen:
+
+Optionen:
+1. nur Wochenende in V1
+2. deutsche Feiertage spaeter ueber kleine Hilfsfunktion oder Bibliothek wie `holidays`
+
+Empfehlung:
+- V1: Wochenende sofort
+- Feiertage V1.1 oder V2
+
+Grund:
+- Feiertagslogik ist nett, aber nicht noetig fuer den ersten nutzbaren Wert
+
+## Content-Strategie
+
+Vorhanden:
+- `docs/TAGESIMPULSE_SEED.md` mit 140 kuratierten Originaltexten
+
+Empfehlung fuer Implementierung:
+- beim Einbau in maschinenlesbares JSON ueberfuehren
+- Tags aus der Seed-Datei uebernehmen
+- spaeter Content separat erweitern
+
+## Testplan
+
+### Backend-Tests
+
+Neue Datei:
+- `tests/test_daily_impulse_service.py`
+
+Testfaelle:
+- liefert `None`, wenn deaktiviert
+- liefert fuer denselben Tag denselben Impuls
+- liefert fuer verschiedene Kontexte unterschiedliche Kandidatenbereiche
+- priorisiert Wochenende/Follow-up/etc. korrekt
+- faellt auf `default` zurueck
+
+### API-Tests
+
+Erweiterung in:
+- `tests/test_dashboard.py`
+
+Testfaelle:
+- `/api/daily-impulse` liefert gueltige Struktur
+- deaktivierter Impuls liefert `enabled=false` oder `impulse=null`
+
+### Browser-Tests
+
+Erweiterung in:
+- `tests/test_dashboard_browser.py`
+
+Testfaelle:
+- Karte sichtbar im Dashboard
+- Toggle in Einstellungen deaktiviert Anzeige
+
+## Konfliktarme Umsetzung
+
+Damit Claude parallel zu anderer GitHub-Arbeit wenig Konflikte hat, sollte die Einfuehrung so geschnitten werden:
+
+### Niedrige Konfliktwahrscheinlichkeit
+
+- neue Content-Datei
+- neuer Service `daily_impulse_service.py`
+- neuer API-Endpoint
+- kleine Card-Komponente
+- kleiner Settings-Toggle
+
+### Hoehere Konfliktwahrscheinlichkeit
+
+- grosse Umbauten in `DashboardPage.jsx`
+- breite Refactors im Settings-Bereich
+
+### Empfehlung
+
+Den Einbau in 3 kleine Schritte schneiden:
+
+1. Content + Service + API
+2. kleine Dashboard-Karte
+3. Settings-Toggle + Tests
+
+## Empfohlene Reihenfolge fuer Claude
+
+1. Seed-Datei in JSON-Struktur ueberfuehren
+2. `daily_impulse_service.py` bauen
+3. `/api/daily-impulse` einfuehren
+4. Dashboard-Karte einbauen
+5. Toggle in Einstellungen
+6. Tests ergaenzen
+7. Ton/Spacing im UI feinziehen
+
+## Ehrliche Priorisierung
+
+Das Feature ist sinnvoll, aber nicht kritisch fuer die Kernfunktion von PBP.
+
+Es lohnt sich, wenn:
+- die Umsetzung klein bleibt
+- die Texte hochwertig bleiben
+- das Feature optional und unaufdringlich ist
+
+Es lohnt sich nicht, wenn:
+- es in grossen UI-Umbauten endet
+- die Sammlung lieblos oder austauschbar wirkt
+- es mit zu viel Logik ueberladen wird
+
+## Fazit
+
+Die Idee ist produktseitig gut.
+
+Der richtige Einstieg ist:
+- kleine, saubere V1
+- kuratierter Content
+- einfache Kontextlogik
+- keine Ueberautomatisierung
+
+So bleibt das Feature charmant und kippt nicht in Gimmick oder Kitsch.

--- a/docs/TAGESIMPULSE_SEED.md
+++ b/docs/TAGESIMPULSE_SEED.md
@@ -1,0 +1,188 @@
+# PBP Tagesimpulse Seed v1
+
+Stand: 2026-03-21
+
+Ziel:
+- Erste kuratierte Sammlung fuer ein spaeteres Dashboard-Feature
+- Originale PBP-Texte, keine Kalenderspruch-Floskeln
+- Mix aus Motivation, Humor, Ernst, Ruhe und kleinen Schubsern
+
+Hinweise:
+- Alle Texte sind bewusst kurz gehalten
+- Tags sind nur ein Startpunkt fuer spaetere Logik
+- Die Sammlung ist erweiterbar
+
+## Format
+
+`[Nummer] [Tags] Text`
+
+Beispiel:
+`[001] [ermutigend,profil] Heute musst du nicht alles loesen. Du musst nur wieder anfangen.`
+
+## Sammlung
+
+[001] [ermutigend,alltag] Heute musst du nicht alles loesen. Du musst nur wieder anfangen.
+[002] [ermutigend,alltag] Ein kleiner Schritt zaehlt auch dann, wenn er sich nicht heroisch anfuehlt.
+[003] [ernst,alltag] Bewerbungen sind Arbeit. Dass es anstrengend ist, heisst nicht, dass du etwas falsch machst.
+[004] [ermutigend,alltag] Du bist nicht spaet. Du bist mitten in deinem Weg.
+[005] [humor,alltag] Falls heute nur Kaffee und ein klarer Gedanke drin sind: beides ist schon Teamarbeit.
+[006] [ermutigend,alltag] Fortschritt ist oft leiser, als man ihn sich wuenscht.
+[007] [ernst,alltag] Nicht jeder starke Tag fuehlt sich stark an.
+[008] [ermutigend,alltag] Du musst heute nicht glaenzen. Du musst nur dranbleiben.
+[009] [sarkastisch_leicht,alltag] Dein innerer Kritiker hat heute wieder Sprechstunde. Du musst nicht hingehen.
+[010] [ermutigend,alltag] Auch ein unspektakulaerer Tag kann ein guter Tag fuer deinen Weg sein.
+[011] [humor,alltag] Perfektion ist heute ausgebucht. Solide reicht.
+[012] [ernst,alltag] Wer sucht, zweifelt manchmal. Das ist normal, nicht peinlich.
+[013] [ermutigend,alltag] Nur weil es laenger dauert, wird es nicht falscher.
+[014] [ermutigend,alltag] Du baust hier nicht nur Bewerbungen. Du baust Richtung.
+[015] [ernst,alltag] Muede sein und weitermachen koennen gleichzeitig wahr sein.
+[016] [humor,alltag] Heute ist ein guter Tag fuer weniger Drama und mehr naechsten sinnvollen Schritt.
+[017] [ermutigend,alltag] Der Weg muss nicht elegant sein. Er muss nur weitergehen.
+[018] [ruhe,alltag] Atmen, sortieren, weitermachen. Mehr verlangt heute niemand.
+[019] [ermutigend,alltag] Manchmal ist Disziplin einfach nur: wieder auftauchen.
+[020] [ernst,alltag] Auch wenn gerade wenig zurueckkommt: dein Einsatz verschwindet nicht.
+
+[021] [profil,ermutigend] Jedes gute Profil beginnt mit unvollstaendigen Notizen.
+[022] [profil,ernst] Ein gutes Profil ist kein Schmuckstueck. Es ist dein Arbeitswerkzeug.
+[023] [profil,ermutigend] Wenn du dein Profil verbesserst, machst du keine Umwege. Du machst den Rest leichter.
+[024] [profil,humor] Kein Lebenslauf faellt fertig vom Himmel. Sonst haetten Recruiter Fluegel.
+[025] [profil,ernst] Klarheit ueber dich selbst ist kein Luxus. Sie spart spaeter Kraft.
+[026] [profil,ermutigend] Eine gute Formulierung kann sichtbar machen, was du laengst kannst.
+[027] [profil,alltag] Heute reicht es, einen Abschnitt besser zu machen als gestern.
+[028] [profil,humor] Dein Profil muss nicht perfekt sein. Es muss nur nicht mehr aus 2019 sprechen.
+[029] [profil,ermutigend] Du schaerfst dein Werkzeug, wenn du dein Profil schaerfst.
+[030] [profil,ernst] Wer sein Profil pflegt, nimmt die eigene Geschichte ernst.
+[031] [profil,ermutigend] Es ist kein Rueckschritt, Grundlagen sauber zu ziehen.
+[032] [profil,alltag] Ein klarer Satz ueber dich ist oft mehr wert als drei vage Buzzwords.
+[033] [profil,humor] Wenn ein Satz auch auf einen Staubsauger passen wuerde, ist er noch nicht gut genug.
+[034] [profil,ermutigend] Nicht alles an dir muss aussergewoehnlich sein. Vieles darf einfach belastbar sein.
+[035] [profil,ernst] Substanz schlaegt Dekoration.
+[036] [profil,ermutigend] Je ehrlicher dein Profil, desto besser kann es fuer dich arbeiten.
+[037] [profil,alltag] Ein nachgeschliffener Absatz heute ist weniger Chaos morgen.
+[038] [profil,ermutigend] Du musst dich nicht groesser schreiben. Nur klarer.
+[039] [profil,humor] Recruiter suchen kein Maerchen. Die meisten waeren schon froh ueber Verben.
+[040] [profil,ernst] Ein gutes Profil ist kein Prahlen. Es ist Orientierung.
+
+[041] [jobsuche,ermutigend] Neue Suche, neue Chancen. So unspektakulaer beginnt Bewegung.
+[042] [jobsuche,ernst] Wer nicht sucht, findet oft nur Zufall.
+[043] [jobsuche,alltag] Eine frische Suche ist manchmal produktiver als zehn Minuten Grübeln.
+[044] [jobsuche,humor] Jobportale sind selten romantisch. Deshalb brauchst du Struktur.
+[045] [jobsuche,ermutigend] Nicht jede Suche bringt Treffer. Aber jede gute Suche schaerft den Blick.
+[046] [jobsuche,ernst] Aktualitaet ist in der Jobsuche keine Kleinigkeit.
+[047] [jobsuche,alltag] Heute reicht auch: Quellen checken, Suche anstossen, weitersehen.
+[048] [jobsuche,ermutigend] Gute Treffer kommen oft nach dem Moment, an dem man kurz keine Lust mehr hat.
+[049] [jobsuche,humor] Suchfilter sind die stille Heldengruppe gegen beruflichen Unsinn.
+[050] [jobsuche,ernst] Wenn du nicht waehlst, waehlt spaeter der Zufall fuer dich.
+[051] [jobsuche,ermutigend] Ein klarer Suchradius ist keine Begrenzung. Er ist Fokus.
+[052] [jobsuche,alltag] Heute musst du nicht den perfekten Job finden. Nur den naechsten guten Treffer.
+[053] [jobsuche,humor] Nicht jede Stelle mit Obstkorb ist gleich Kultur.
+[054] [jobsuche,ernst] Je sauberer deine Suche, desto weniger Energie verschwendest du.
+[055] [jobsuche,ermutigend] Viele gute Entscheidungen sehen zuerst nur wie Sortierarbeit aus.
+[056] [jobsuche,alltag] Auch Aussortieren ist Fortschritt.
+[057] [jobsuche,humor] Ein schlechtes Inserat frueh zu erkennen ist keine Negativitaet. Es ist Reife.
+[058] [jobsuche,ermutigend] Du musst nicht alles pruefen. Nur das, was dich wirklich weiterbringen koennte.
+[059] [jobsuche,ernst] Wer regelmaessig sucht, bleibt handlungsfaehig.
+[060] [jobsuche,alltag] Vielleicht ist heute kein Karrieresprungtag. Aber ein Suchlauf geht trotzdem.
+
+[061] [bewerbung,ermutigend] Du brauchst nicht zehn perfekte Bewerbungen. Du brauchst die naechste gute.
+[062] [bewerbung,ernst] Eine abgeschickte Bewerbung ist besser als eine idealisierte im Kopf.
+[063] [bewerbung,alltag] Heute darf die Aufgabe klein sein: eine Bewerbung sauber finalisieren.
+[064] [bewerbung,humor] Wenn du die Mail dreimal gelesen hast, ist sie wahrscheinlich fertig.
+[065] [bewerbung,ermutigend] Mut sieht im Alltag oft wie Senden aus.
+[066] [bewerbung,ernst] Eine Bewerbung ist kein Liebesbrief. Klarheit gewinnt.
+[067] [bewerbung,alltag] Auch eine solide Bewerbung kann die richtige sein.
+[068] [bewerbung,ermutigend] Du musst nicht originell um jeden Preis sein. Du musst erkennbar sein.
+[069] [bewerbung,humor] Falls du schon wieder am Betreff zweifelst: niemand wird daran dein Schicksal festmachen.
+[070] [bewerbung,ernst] Anschreiben sollen tragen, nicht tanzen.
+[071] [bewerbung,ermutigend] Es reicht, wenn deine Bewerbung glaubwuerdig, klar und passend ist.
+[072] [bewerbung,alltag] Vielleicht ist heute einfach ein guter Tag fuer abschicken statt ueberdenken.
+[073] [bewerbung,humor] Die perfekte Formulierung kommt meistens fuenf Minuten nach dem Senden. Das ist Tradition.
+[074] [bewerbung,ernst] Wer sich bewirbt, zeigt Richtung. Nicht Verzweiflung.
+[075] [bewerbung,ermutigend] Jede abgeschlossene Bewerbung nimmt Druck aus dem Kopf.
+[076] [bewerbung,alltag] Heute muss nicht brillant werden. Heute darf rausgehen.
+[077] [bewerbung,humor] Kein Recruiter sitzt da und denkt: schade, nur 97 Prozent poetisch.
+[078] [bewerbung,ernst] Bewerbungstempo ist auch Selbstfuehrung.
+[079] [bewerbung,ermutigend] Du darfst auf passende Stellen ernsthaft zugehen. Wirklich.
+[080] [bewerbung,alltag] Eine Bewerbung weniger offen ist ein gutes Tagesergebnis.
+
+[081] [nachfassen,ermutigend] Nachfassen ist kein Stoeren. Es ist professionelles Erinnern.
+[082] [nachfassen,ernst] Wenn du dich meldest, nimmst du deine eigene Bewerbung ernst.
+[083] [nachfassen,alltag] Heute koennte ein guter Tag fuer eine kurze, klare Nachfrage sein.
+[084] [nachfassen,humor] Freundlich nachfassen ist keine peinliche Ex-Nachricht. Es ist Business.
+[085] [nachfassen,ermutigend] Viele Chancen brauchen einen zweiten Ping.
+[086] [nachfassen,ernst] Stille ist nicht immer Ablehnung. Manchmal ist sie einfach nur Betrieb.
+[087] [nachfassen,alltag] Ein sauberer Follow-up spart spaeter mehr Kopfkino, als man denkt.
+[088] [nachfassen,humor] Wenn Unternehmen tagelang schweigen, darfst du trotzdem gute Manieren behalten. Muss aber nicht begeistert machen.
+[089] [nachfassen,ermutigend] Klar nachfragen ist oft staerker als still leiden.
+[090] [nachfassen,ernst] Wer professionell nachfasst, zeigt Haltung.
+
+[091] [absage,ernst] Eine Absage ist eine Antwort, kein Urteil ueber deinen Wert.
+[092] [absage,ermutigend] Du darfst enttaeuscht sein und trotzdem weitergehen.
+[093] [absage,ruhe] Heute musst du aus einer Absage noch nichts Kluges machen.
+[094] [absage,humor] Manche Unternehmen wissen schlicht nicht, was sie verpassen. Das kommt vor.
+[095] [absage,ernst] Nicht jedes Nein laesst sich verbessern. Aber manches laesst sich einordnen.
+[096] [absage,ermutigend] Eine Absage nimmt dir eine Option. Nicht deine Richtung.
+[097] [absage,ruhe] Du schuldest einer Absage nicht sofort neue Energie.
+[098] [absage,ernst] Rueckschlaege sind Teil der Suche, nicht ihr Beweis des Scheiterns.
+[099] [absage,ermutigend] Es ist erlaubt, kurz zu fluchen und spaeter klug weiterzumachen.
+[100] [absage,humor] Wenn sie dich nicht wollten, muss wenigstens der Kaffee heute auf deiner Seite sein.
+
+[101] [wochenende,ruhe] Wochenende ist nicht Versagen mit anderer Uhrzeit.
+[102] [wochenende,ruhe] Auch Jobsuche braucht Pausen, sonst sucht am Ende nur noch deine Erschoepfung.
+[103] [wochenende,ermutigend] Ein freier Kopf ist manchmal die beste Vorbereitung fuer Montag.
+[104] [wochenende,humor] Du darfst heute den Laptop anschauen, ohne dass daraus Arbeit werden muss.
+[105] [wochenende,ruhe] Ausruhen ist kein Abbruch. Es ist Wartung.
+[106] [wochenende,ernst] Wer dauerhaft unter Strom steht, trifft selten die besten Entscheidungen.
+[107] [wochenende,ermutigend] Heute darf langsam sein.
+[108] [wochenende,humor] Selbst dein Lebenslauf will nicht, dass du sonntags an Bulletpoints zerbrichst.
+[109] [wochenende,ruhe] Wenn du heute nur Kraft sammelst, war das nicht zu wenig.
+[110] [wochenende,ernst] Regeneration ist Teil von Leistungsfaehigkeit, nicht ihr Gegner.
+
+[111] [feiertag,ruhe] Heute darfst du erinnern, dass du mehr bist als dein Bewerbungsstatus.
+[112] [feiertag,ruhe] Feiertage muessen nichts leisten. Du auch nicht unbedingt.
+[113] [feiertag,ermutigend] Ein Tag Pause macht deine Ziele nicht kleiner.
+[114] [feiertag,humor] Selbst Karriereplaene haben Feiertage. Sonst waeren sie Steuererklaerungen.
+[115] [feiertag,ruhe] Heute ist ein guter Tag fuer Luft holen statt Listen.
+[116] [feiertag,ernst] Wer sich Auszeit erlaubt, bleibt laenger handlungsfaehig.
+[117] [feiertag,ermutigend] Morgen geht es weiter. Heute darf es stiller sein.
+[118] [feiertag,humor] Die Stellenportale laufen dir heute nicht in den See.
+[119] [feiertag,ruhe] Nicht jeder freie Tag muss optimiert werden.
+[120] [feiertag,ernst] Manchmal ist Abstand die produktivste Form von Klarheit.
+
+[121] [humor,alltag] Du bist kein Produkt. Aber ein bisschen bessere Verpackung schadet bei Bewerbungen trotzdem nicht.
+[122] [humor,alltag] Heute bitte weniger Selbstzweifel und mehr Datei version_final_wirklich_final.
+[123] [humor,jobsuche] Wenn eine Anzeige gleichzeitig Rockstar, Ninja und Allrounder sucht, sucht sie wahrscheinlich Fantasie.
+[124] [humor,bewerbung] Klarheit ist sexy. Vor allem fuer Menschen, die 84 Bewerbungen lesen muessen.
+[125] [humor,profil] Drei Buzzwords in Folge sind noch kein Persoenlichkeitsmerkmal.
+[126] [humor,alltag] Du musst heute nicht die Welt erobern. Ein sauberer Absatz reicht schon fuer diplomatische Fortschritte.
+[127] [humor,nachfassen] Wer sich nie meldet, wirkt nicht cool. Nur schwer auffindbar.
+[128] [humor,alltag] Vielleicht ist dein naechster Karriereschritt einfach besser organisiert als dein letzter Download-Ordner.
+[129] [humor,wochenende] Das Wochenende ist kein leeres Feld in deiner Produktivitaets-App.
+[130] [humor,absage] Manche Absagen sind einfach das Universum in Business Casual.
+
+[131] [ermutigend,alltag] Heute darfst du dir selbst glauben, auch ohne externen Applaus.
+[132] [ermutigend,alltag] Es ist genug, wenn du heute den Faden wieder aufnimmst.
+[133] [ermutigend,alltag] Dein Weg muss nicht beeindrucken. Er muss zu dir passen.
+[134] [ermutigend,alltag] Nicht jede gute Entwicklung sieht von innen nach Erfolg aus.
+[135] [ermutigend,alltag] Du brauchst keinen perfekten Plan fuer den naechsten vernuenftigen Schritt.
+[136] [ermutigend,alltag] Du bist nicht nur auf der Suche. Du bist auch im Aufbau.
+[137] [ermutigend,alltag] Was heute klein wirkt, kann morgen der Teil sein, der alles traegt.
+[138] [ermutigend,alltag] Manchmal ist Hoffnung einfach gute Routine.
+[139] [ermutigend,alltag] Du darfst dir Zeit lassen, solange du dich nicht aufgibst.
+[140] [ermutigend,alltag] Bleib freundlich zu dir. Du arbeitest hier nicht gegen dich.
+
+## Naechste sinnvolle Ausbaustufen
+
+- Duplikate im Ton pruefen und enger kuratieren
+- Weitere Cluster ergaenzen:
+  - Interview
+  - Gehalt
+  - Freelance
+  - Wiedereinstieg
+  - Langsame Tage
+- Sprachniveau noch feiner unterscheiden:
+  - warm
+  - trocken
+  - frech
+  - ruhig
+- Fuer spaetere Implementierung in JSON ueberfuehren


### PR DESCRIPTION
## Zusammenfassung

Dieser PR fuehrt das Tagesimpuls-Feature noch nicht technisch ein. Er bereitet es so vor, dass Claude spaeter konfliktarm integrieren kann.

## Enthalten

- Seed-Sammlung mit 140 originalen Tagesimpulsen
- produktseitiger und technischer Implementierungsplan
- Claude-Handoff fuer die spaetere Umsetzung

## Dateien

- `docs/TAGESIMPULSE_SEED.md`
- `docs/TAGESIMPULSE_IMPLEMENTIERUNGSPLAN.md`
- `docs/CODEX_CLAUDE_TAGESIMPULSE_HANDOFF.md`

## GitHub-Kontext

- Bezug: #163

## Ziel des Schnitts

Moeglichst wenig Konfliktflaeche zu laufender Issue-Arbeit:
- keine Aenderungen an `dashboard.py`
- keine Aenderungen an `DashboardPage.jsx`
- keine API-/DB-Aenderungen in diesem PR

Claude kann spaeter auf dieser Basis direkt die eigentliche Integration bauen.
