### PR TITLE
chore: FUNDING.yml mit PayPal-Spendenlink

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ['https://paypal.me/birzite']


### PR DESCRIPTION
## Summary
- `.github/FUNDING.yml` hinzugefügt — zeigt Sponsor-Button auf dem GitHub Repo
- Link: paypal.me/birzite

Nur Repo-Metadaten, keine Code-Änderung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)