### PR TITLE
fix: MCP-Tool Timeout + Zombie-Cleanup (#303)

### DIFF
--- a/src/bewerbungs_assistent/server.py
+++ b/src/bewerbungs_assistent/server.py
@@ -26,6 +26,21 @@ logger = logging.getLogger("bewerbungs_assistent")
 db = Database()
 db.initialize()
 
+# #303: Zombie-Background-Jobs bereinigen (status='running' von vorherigem Absturz)
+try:
+    conn = db.connect()
+    zombie_count = conn.execute(
+        "UPDATE background_jobs SET status='abgebrochen', "
+        "message='Server-Neustart: Job war noch als running markiert', "
+        "updated_at=datetime('now') "
+        "WHERE status IN ('running', 'pending')"
+    ).rowcount
+    conn.commit()
+    if zombie_count:
+        logger.info("Zombie-Jobs bereinigt: %d Jobs auf 'abgebrochen' gesetzt", zombie_count)
+except Exception as e:
+    logger.warning("Zombie-Job-Cleanup fehlgeschlagen: %s", e)
+
 # Create MCP server
 mcp = FastMCP(
     "Bewerbungs-Assistent",
@@ -40,15 +55,40 @@ from fastmcp.server.middleware import Middleware
 
 
 class HeartbeatMiddleware(Middleware):
-    """Loggt jeden Tool-Aufruf und schreibt Heartbeat fuer Dashboard-Status."""
+    """Loggt jeden Tool-Aufruf, schreibt Heartbeat und erzwingt Timeouts (#303)."""
+
+    # Tools die länger laufen dürfen (z.B. Jobsuche mit Scrapern)
+    LONG_RUNNING_TOOLS = {"jobsuche_starten", "jobsuche_status"}
+    DEFAULT_TIMEOUT = 60  # Sekunden
+    LONG_TIMEOUT = 300    # 5 Minuten für Scraper-Tools
 
     async def on_call_tool(self, context, call_next):
+        import asyncio
         tool_name = context.message.name if context.message else "unknown"
         logger.info("Tool aufgerufen: %s", tool_name)
         write_heartbeat(tool_name)
+
+        timeout = self.LONG_TIMEOUT if tool_name in self.LONG_RUNNING_TOOLS else self.DEFAULT_TIMEOUT
+
         try:
-            result = await call_next(context)
+            result = await asyncio.wait_for(call_next(context), timeout=timeout)
             return result
+        except asyncio.TimeoutError:
+            logger.error("Tool %s Timeout nach %ds", tool_name, timeout)
+            # Strukturierter Fehler statt Silence (#303)
+            from fastmcp.tools.tool import ToolResult
+            from mcp.types import TextContent
+            error_msg = json.dumps({
+                "error": "timeout",
+                "tool": tool_name,
+                "timeout_seconds": timeout,
+                "message": (
+                    f"Tool '{tool_name}' hat nach {timeout} Sekunden nicht geantwortet. "
+                    f"Mögliche Ursache: DB-Lock oder externer Service nicht erreichbar. "
+                    f"Bitte versuche es erneut."
+                ),
+            }, ensure_ascii=False)
+            return ToolResult(content=[TextContent(type="text", text=error_msg)])
         except Exception as e:
             logger.error("Tool %s Fehler: %s", tool_name, e, exc_info=True)
             raise


### PR DESCRIPTION
## Summary
- **Globaler Timeout**: 60s (normal) / 300s (Scraper) pro MCP-Tool-Call via Middleware
- **Strukturierter Fehler**: Bei Timeout kommt JSON mit `error`, `tool`, `timeout_seconds`, `message` — nicht mehr Silence
- **Zombie-Cleanup**: Beim Server-Start werden alle `running`/`pending` Background-Jobs auf `abgebrochen` gesetzt

## Architektur
Timeout wird in `HeartbeatMiddleware.on_call_tool()` via `asyncio.wait_for()` erzwungen.
Rückgabe bei Timeout ist ein `ToolResult` mit `TextContent` — Claude erhält einen verständlichen Fehler.

## Test plan
- [x] 368 Unit-Tests grün
- [ ] Manuell: Tool mit DB-Lock provozieren → Fehler nach 60s statt 4-Min-Silence
- [ ] Manuell: Server neustarten mit alten `running`-Jobs → werden bereinigt

Fixes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)