### PR TITLE
fix: MCP-Verbindungsstatus — periodischer Heartbeat (#304)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -692,7 +692,7 @@ export default function App() {
               const st = conn?.status || "disconnected";
               const cfg = {
                 connected: { color: "text-teal", bg: "bg-teal/15", label: "Verbunden", Icon: Link2 },
-                unknown: { color: "text-amber", bg: "bg-amber/15", label: "Unbekannt", Icon: Link2 },
+                unknown: { color: "text-amber", bg: "bg-amber/15", label: "Pr\u00fcfe\u2026", Icon: Link2 },
                 disconnected: { color: "text-coral", bg: "bg-coral/15", label: "Nicht verbunden", Icon: Link2Off },
               }[st] || { color: "text-coral", bg: "bg-coral/15", label: "Nicht verbunden", Icon: Link2Off };
               return (

--- a/src/bewerbungs_assistent/heartbeat.py
+++ b/src/bewerbungs_assistent/heartbeat.py
@@ -1,10 +1,13 @@
-"""MCP Heartbeat — schreibt Zeitstempel bei jedem Tool-Aufruf.
+"""MCP Heartbeat — schreibt Zeitstempel bei jedem Tool-Aufruf + periodisch (#304).
 
 Das Dashboard liest diese Datei um den Verbindungsstatus anzuzeigen.
+Periodischer Heartbeat alle 30s zeigt, dass der MCP-Server-Prozess lebt,
+auch wenn gerade kein Tool aufgerufen wird.
 """
 
 import json
 import logging
+import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -15,28 +18,64 @@ logger = logging.getLogger("bewerbungs_assistent.heartbeat")
 
 _HEARTBEAT_FILE = "mcp_heartbeat.json"
 
-# Throttle: maximal alle 10 Sekunden schreiben
+# Throttle: maximal alle 10 Sekunden schreiben (für Tool-Calls)
 _last_write: float = 0.0
 _THROTTLE_SECONDS = 10
 
+# Periodischer Heartbeat (#304)
+_PERIODIC_INTERVAL = 30  # Sekunden
+_periodic_thread: threading.Thread | None = None
+
+
+def _write_heartbeat_file(tool_name: str, is_alive: bool = False) -> None:
+    """Schreibt Heartbeat-Datei."""
+    try:
+        path = get_data_dir() / _HEARTBEAT_FILE
+        data = {
+            "last_heartbeat": datetime.now(timezone.utc).isoformat(),
+            "last_tool_call": datetime.now(timezone.utc).isoformat() if not is_alive else None,
+            "tool": tool_name,
+            "type": "alive" if is_alive else "tool_call",
+        }
+        # Merge with existing data to preserve last_tool_call
+        if is_alive:
+            existing = read_heartbeat()
+            if existing:
+                data["last_tool_call"] = existing.get("last_tool_call")
+                data["tool"] = existing.get("tool", tool_name)
+        path.write_text(json.dumps(data), encoding="utf-8")
+    except Exception as e:
+        logger.debug("Heartbeat schreiben fehlgeschlagen: %s", e)
+
 
 def write_heartbeat(tool_name: str) -> None:
-    """Schreibt Heartbeat-Datei mit Zeitstempel und Tool-Name."""
+    """Schreibt Heartbeat-Datei mit Zeitstempel und Tool-Name (throttled)."""
     global _last_write
     now = time.monotonic()
     if now - _last_write < _THROTTLE_SECONDS:
         return
     _last_write = now
+    _write_heartbeat_file(tool_name, is_alive=False)
 
-    try:
-        path = get_data_dir() / _HEARTBEAT_FILE
-        data = {
-            "last_tool_call": datetime.now(timezone.utc).isoformat(),
-            "tool": tool_name,
-        }
-        path.write_text(json.dumps(data), encoding="utf-8")
-    except Exception as e:
-        logger.debug("Heartbeat schreiben fehlgeschlagen: %s", e)
+
+def start_periodic_heartbeat() -> None:
+    """Startet periodischen Heartbeat-Thread (#304).
+
+    Schreibt alle 30 Sekunden einen Alive-Heartbeat, damit das Dashboard
+    erkennen kann, dass der MCP-Server-Prozess lebt — auch ohne Tool-Calls.
+    """
+    global _periodic_thread
+    if _periodic_thread and _periodic_thread.is_alive():
+        return
+
+    def _periodic():
+        while True:
+            _write_heartbeat_file("alive_ping", is_alive=True)
+            time.sleep(_PERIODIC_INTERVAL)
+
+    _periodic_thread = threading.Thread(target=_periodic, daemon=True, name="heartbeat-periodic")
+    _periodic_thread.start()
+    logger.debug("Periodischer Heartbeat gestartet (alle %ds)", _PERIODIC_INTERVAL)
 
 
 def read_heartbeat() -> dict | None:
@@ -52,36 +91,48 @@ def read_heartbeat() -> dict | None:
 
 
 def get_connection_status() -> dict:
-    """Ermittelt Verbindungsstatus basierend auf Heartbeat.
+    """Ermittelt Verbindungsstatus basierend auf Heartbeat (#304).
+
+    Statusübergänge:
+    - connected: Heartbeat < 90s alt (Server lebt + sendet periodisch)
+    - unknown:   Heartbeat 90s-300s alt (kurzer Ausfall, prüfe...)
+    - disconnected: Heartbeat > 300s alt oder nicht vorhanden
 
     Returns:
         {"status": "connected"|"unknown"|"disconnected",
          "last_tool_call": ISO-Timestamp oder None,
-         "last_tool": Tool-Name oder None}
+         "last_tool": Tool-Name oder None,
+         "seconds_since_heartbeat": int oder None}
     """
     hb = read_heartbeat()
     if hb is None:
-        return {"status": "disconnected", "last_tool_call": None, "last_tool": None}
+        return {"status": "disconnected", "last_tool_call": None, "last_tool": None,
+                "seconds_since_heartbeat": None}
 
-    last_call = hb.get("last_tool_call")
-    if not last_call:
-        return {"status": "disconnected", "last_tool_call": None, "last_tool": None}
+    # Nutze last_heartbeat (periodisch) statt last_tool_call
+    heartbeat_ts = hb.get("last_heartbeat") or hb.get("last_tool_call")
+    if not heartbeat_ts:
+        return {"status": "disconnected", "last_tool_call": None, "last_tool": None,
+                "seconds_since_heartbeat": None}
 
     try:
-        last_dt = datetime.fromisoformat(last_call)
+        last_dt = datetime.fromisoformat(heartbeat_ts)
         age_seconds = (datetime.now(timezone.utc) - last_dt).total_seconds()
     except (ValueError, TypeError):
-        return {"status": "unknown", "last_tool_call": last_call, "last_tool": hb.get("tool")}
+        return {"status": "unknown", "last_tool_call": hb.get("last_tool_call"),
+                "last_tool": hb.get("tool"), "seconds_since_heartbeat": None}
 
-    if age_seconds < 300:  # 5 Minuten
+    # Engere Schwellen dank periodischem Heartbeat (alle 30s)
+    if age_seconds < 90:       # 3x Heartbeat-Intervall
         status = "connected"
-    elif age_seconds < 3600:  # 1 Stunde
+    elif age_seconds < 300:    # 5 Minuten
         status = "unknown"
     else:
         status = "disconnected"
 
     return {
         "status": status,
-        "last_tool_call": last_call,
+        "last_tool_call": hb.get("last_tool_call"),
         "last_tool": hb.get("tool"),
+        "seconds_since_heartbeat": round(age_seconds),
     }

--- a/src/bewerbungs_assistent/server.py
+++ b/src/bewerbungs_assistent/server.py
@@ -15,7 +15,7 @@ import functools
 from fastmcp import FastMCP
 
 from .database import Database, get_data_dir
-from .heartbeat import write_heartbeat
+from .heartbeat import write_heartbeat, start_periodic_heartbeat
 
 # Logging: Datei + stderr (stdout ist für MCP-Protokoll reserviert!)
 from .logging_config import setup_logging
@@ -185,6 +185,8 @@ def run_server():
 
     # Heartbeat beim Start schreiben (#295) — Dashboard zeigt sofort "Verbunden"
     write_heartbeat("server_start")
+    # #304: Periodischer Heartbeat — Dashboard erkennt ob Server lebt (ohne Tool-Calls)
+    start_periodic_heartbeat()
 
     # Run MCP server (blocks on stdio)
     from . import __version__


### PR DESCRIPTION
## Summary
- **Periodischer Heartbeat**: Alle 30s schreibt der MCP-Server einen Alive-Ping (Daemon-Thread)
- **Engere Schwellen**: connected < 90s, unknown 90-300s, disconnected > 300s
- **Besseres UX**: "Unbekannt" → "Prüfe…" — kein stabiler Endzustand mehr
- **Neue Daten**: `seconds_since_heartbeat`, `last_heartbeat`, `type` (alive/tool_call)

## Architektur
`start_periodic_heartbeat()` startet beim Server-Start einen Daemon-Thread, der alle 30s die Heartbeat-Datei aktualisiert. Die bestehende Tool-Call-Heartbeat-Logik bleibt erhalten und überschreibt bei Tool-Calls.

## Test plan
- [x] 368 Unit-Tests grün
- [ ] Manuell: Server starten → Status sofort "Verbunden"
- [ ] Manuell: 2 Minuten kein Tool → Status bleibt "Verbunden" (dank periodischem Heartbeat)
- [ ] Manuell: Server stoppen → nach ~90s Status "Prüfe…", nach 5min "Nicht verbunden"

Fixes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)