### PR TITLE
fix(frontend): Follow-up overflow + klickbar (#314)

### DIFF
--- a/frontend/src/pages/ApplicationsPage.jsx
+++ b/frontend/src/pages/ApplicationsPage.jsx
@@ -547,12 +547,19 @@ export default function ApplicationsPage() {
               <SectionHeading title={`Follow-ups (${followUps.length})`} />
               <div className="grid gap-1.5">
                 {followUps.map((followUp) => (
-                  <div key={followUp.id} className={cn(
-                    "flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm",
-                    followUp.faellig ? "bg-coral/8 border border-coral/15" : "bg-white/[0.03] border border-white/5"
-                  )}>
-                    <CalendarClock size={14} className={followUp.faellig ? "text-coral" : "text-muted/40"} />
-                    <span className="flex-1 truncate text-ink font-medium">{followUp.title} — {followUp.company}</span>
+                  <div
+                    key={followUp.id}
+                    title={`${followUp.title} — ${followUp.company}`}
+                    onClick={() => openTimeline({ id: followUp.application_id })}
+                    className={cn(
+                      "flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm cursor-pointer transition-colors min-w-0",
+                      followUp.faellig
+                        ? "bg-coral/8 border border-coral/15 hover:bg-coral/15"
+                        : "bg-white/[0.03] border border-white/5 hover:bg-white/[0.07]"
+                    )}
+                  >
+                    <CalendarClock size={14} className={cn("shrink-0", followUp.faellig ? "text-coral" : "text-muted/40")} />
+                    <span className="flex-1 min-w-0 truncate text-ink font-medium">{followUp.title} — {followUp.company}</span>
                     <span className="shrink-0 text-xs text-muted/50">{formatDate(followUp.scheduled_date)}</span>
                     <Badge tone={followUp.faellig ? "danger" : "sky"}>{followUp.faellig ? "Fällig" : "Geplant"}</Badge>
                   </div>


### PR DESCRIPTION
## Summary
- Follow-up-Text wird jetzt korrekt mit `truncate` abgeschnitten (`min-w-0` auf Flex-Container)
- Klick auf Follow-up-Eintrag öffnet direkt die Bewerbungs-Timeline
- Hover-Effekt + cursor-pointer signalisieren Klickbarkeit
- title-Attribut zeigt vollständigen Text als Tooltip

## Test plan
- [ ] Follow-up mit langem Titel prüfen — Text wird mit "..." abgeschnitten
- [ ] Klick auf Follow-up öffnet Timeline-Dialog der verknüpften Bewerbung
- [ ] Hover zeigt Farbwechsel und Pointer-Cursor

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)