### PR TITLE
feat(tools): Duplikat-Prüfung gegen Bewerbungen (#317)

### DIFF
--- a/src/bewerbungs_assistent/tools/jobs.py
+++ b/src/bewerbungs_assistent/tools/jobs.py
@@ -553,6 +553,10 @@ def register(mcp, db, logger):
         Firmen-Webseiten) in PBP zu uebertragen. Die Stelle wird automatisch
         bewertet und erscheint in stellen_anzeigen().
 
+        WICHTIG: Vor dem Anlegen wird automatisch geprueft ob bereits eine
+        Bewerbung mit aehnlicher Firma+Titel existiert (#317). Bei Duplikat
+        wird eine Warnung zurueckgegeben und die Stelle NICHT angelegt.
+
         Args:
             titel: Stellentitel (z.B. 'Senior Projektmanager PLM')
             firma: Firmenname
@@ -575,8 +579,57 @@ def register(mcp, db, logger):
         if existing_job:
             return {"fehler": f"Diese Stelle existiert bereits (Hash: {existing_job['hash']})."}
 
-        # Cross-source duplicate detection (#222): Check if similar stelle exists
+        # Duplikat-Prüfung gegen bestehende Bewerbungen (#317)
         import re as _re
+        apps = db.get_applications()
+
+        # 1. URL-basierte Prüfung (stärkster Indikator)
+        if url:
+            url_norm = url.lower().rstrip("/")
+            for app in apps:
+                app_url = (app.get("url") or "").lower().rstrip("/")
+                if app_url and app_url == url_norm:
+                    return {
+                        "warnung": "duplikat_bewerbung",
+                        "nachricht": (
+                            f"Exaktes URL-Duplikat: Bewerbung {app['id'][:8]} bei "
+                            f"{app.get('company')} hat dieselbe URL "
+                            f"(Status: {app.get('status', 'unbekannt')}). "
+                            "Die Stelle wurde NICHT angelegt."
+                        ),
+                        "existing_application_id": app["id"][:8],
+                        "trotzdem_anlegen": False,
+                    }
+
+        # 2. Firma+Titel Fuzzy-Match
+        firma_lower = firma.lower()
+        titel_lower = titel.lower()
+        titel_words = set(titel_lower.split())
+        for app in apps:
+            app_company = (app.get("company") or "").lower()
+            app_title = (app.get("title") or "").lower()
+            # Firma-Match (fuzzy: Teilstring in beide Richtungen)
+            if firma_lower in app_company or app_company in firma_lower:
+                # Titel-Ähnlichkeit: mindestens 2 gemeinsame Wörter
+                app_words = set(app_title.split())
+                overlap = titel_words & app_words
+                if len(overlap) >= min(2, len(titel_words)):
+                    return {
+                        "warnung": "duplikat_bewerbung",
+                        "nachricht": (
+                            f"Mögliches Duplikat: Bewerbung {app['id'][:8]} bei "
+                            f"{app.get('company')} bereits vorhanden "
+                            f"(Status: {app.get('status', 'unbekannt')}, "
+                            f"Titel: '{app.get('title')}'). "
+                            "Die Stelle wurde NICHT angelegt. "
+                            "Falls es sich um eine andere Stelle handelt, "
+                            "verwende einen deutlich abweichenden Titel."
+                        ),
+                        "existing_application_id": app["id"][:8],
+                        "trotzdem_anlegen": False,
+                    }
+
+        # Cross-source duplicate detection (#222): Check if similar stelle exists
         norm_key = _re.sub(r'[^a-z0-9]', '', f"{firma}{titel}".lower())
         all_active = db.get_active_jobs(exclude_applied=False)
         for existing in all_active:

--- a/tests/test_v120_simulations.py
+++ b/tests/test_v120_simulations.py
@@ -397,6 +397,74 @@ class TestSim3RecherchePlusDuplikat:
         assert found_dup, "Duplikat-Erkennung hat die bestehende Stelle nicht gefunden"
         db.close()
 
+    def test_duplikat_erkennung_gegen_bewerbungen(self, tmp_path):
+        """stelle_manuell_anlegen erkennt Duplikate gegen bestehende Bewerbungen (#317)."""
+        db = _build_server(tmp_path)
+        _seed_profile(db)
+
+        # Bewerbung bei TKMS anlegen
+        app_id = db.add_application({
+            "title": "Senior Projektmanager PLM",
+            "company": "TKMS GmbH",
+            "status": "beworben",
+            "url": "https://stepstone.de/jobs/12345",
+        })
+        assert app_id
+
+        # Duplikat-Logik simulieren: gleiche Firma + ähnlicher Titel
+        import re
+        firma = "TKMS GmbH"
+        titel = "Senior Projektmanager PLM Engineering"
+        firma_lower = firma.lower()
+        titel_words = set(titel.lower().split())
+
+        apps = db.get_applications()
+        found_dup = False
+        for app in apps:
+            app_company = (app.get("company") or "").lower()
+            app_title = (app.get("title") or "").lower()
+            if firma_lower in app_company or app_company in firma_lower:
+                app_words = set(app_title.split())
+                overlap = titel_words & app_words
+                if len(overlap) >= min(2, len(titel_words)):
+                    found_dup = True
+                    break
+
+        assert found_dup, (
+            "Duplikat-Erkennung gegen Bewerbungen hat TKMS-Bewerbung nicht erkannt"
+        )
+
+        # URL-Duplikat-Erkennung
+        url = "https://stepstone.de/jobs/12345"
+        url_norm = url.lower().rstrip("/")
+        found_url_dup = False
+        for app in apps:
+            app_url = (app.get("url") or "").lower().rstrip("/")
+            if app_url and app_url == url_norm:
+                found_url_dup = True
+                break
+        assert found_url_dup, "URL-Duplikat-Erkennung hat bestehende Bewerbung nicht erkannt"
+
+        # Kein Duplikat bei anderer Firma
+        apps2 = db.get_applications()
+        firma2 = "Rheinmetall AG"
+        titel2 = "Projektleiter Schiffbau"
+        firma2_lower = firma2.lower()
+        titel2_words = set(titel2.lower().split())
+        no_dup = True
+        for app in apps2:
+            app_company = (app.get("company") or "").lower()
+            app_title = (app.get("title") or "").lower()
+            if firma2_lower in app_company or app_company in firma2_lower:
+                app_words = set(app_title.split())
+                overlap = titel2_words & app_words
+                if len(overlap) >= min(2, len(titel2_words)):
+                    no_dup = False
+                    break
+        assert no_dup, "Falsch-positives Duplikat bei komplett anderer Firma"
+
+        db.close()
+
 
 # ==========================================================
 # SIMULATION 4: E-Mail-Kontakt + Bewerbung (#225 + alte Pipeline)


### PR DESCRIPTION
## Summary
- `stelle_manuell_anlegen` prüft jetzt vor dem Anlegen gegen bestehende Bewerbungen
- URL-basierte Duplikat-Erkennung (exakter URL-Match)
- Firma+Titel Fuzzy-Match (Teilstring-Firma + min. 2 gemeinsame Wörter im Titel)
- Warnung enthält Bewerbungs-ID, Status und Firmenname

## Test plan
- [ ] Stelle anlegen mit URL einer bestehenden Bewerbung → Duplikat-Warnung
- [ ] Stelle bei gleicher Firma mit ähnlichem Titel → Duplikat-Warnung
- [ ] Stelle bei anderer Firma → wird normal angelegt
- [ ] `test_duplikat_erkennung_gegen_bewerbungen` bestanden

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)