### PR TITLE
feat(scoring): Hochschulabschluss-Erkennung in Fit-Analyse (#305)

### DIFF
--- a/src/bewerbungs_assistent/dashboard.py
+++ b/src/bewerbungs_assistent/dashboard.py
@@ -1319,6 +1319,12 @@ async def api_fit_analyse(job_hash: str):
     if not job:
         return JSONResponse({"error": "Stelle nicht gefunden"}, status_code=404)
     criteria = _db.get_search_criteria()
+    # #305: Education + Skills für Hochschulabschluss-Erkennung
+    profile = _db.get_profile()
+    if profile:
+        skills = profile.get("skills", [])
+        criteria["_profile_skills"] = [s.get("name", "").lower() for s in skills if s.get("name")]
+        criteria["_profile_education"] = profile.get("education", [])
     return fit_analyse(job, criteria)
 
 

--- a/src/bewerbungs_assistent/job_scraper/__init__.py
+++ b/src/bewerbungs_assistent/job_scraper/__init__.py
@@ -1028,8 +1028,21 @@ def fit_analyse(job: dict, criteria: dict) -> dict:
         if len(skill_miss) > len(skill_hits) and skill_miss:
             risks.append(f"Wenige deiner Kompetenzen erwaehnt ({len(skill_hits)}/{len(skill_hits)+len(skill_miss)})")
 
-    # #180: Warnung bei fehlender Beschreibung
+    # #305: Hochschulabschluss-Erkennung
     desc = job.get("description") or ""
+    degree_required = _detect_degree_required(f"{job.get('title', '')} {desc}")
+    has_degree = _profile_has_degree(criteria)
+    if degree_required and not has_degree:
+        risks.insert(0,
+            "HOCHSCHULABSCHLUSS GEFORDERT — Stelle fordert formalen Abschluss "
+            "(Studium/Bachelor/Master). Dein Profil enthält keinen. "
+            "Risiko: Automatische ATS-Aussortierung möglich, "
+            "selbst bei passender Berufserfahrung."
+        )
+        factors["Hochschulabschluss fehlt"] = -2
+        total -= 2
+
+    # #180: Warnung bei fehlender Beschreibung
     if len(desc.strip()) < 50:
         risks.insert(0, "BESCHREIBUNG FEHLT — Score ist unzuverlässig! "
                      "Lade die Stellenbeschreibung nach (stelle_manuell_anlegen oder URL öffnen).")
@@ -1042,7 +1055,69 @@ def fit_analyse(job: dict, criteria: dict) -> dict:
         "factors": factors,
         "risks": risks,
         "beschreibung_vorhanden": len(desc.strip()) >= 50,
+        "hochschulabschluss_gefordert": degree_required,
     }
+
+
+# Hochschulabschluss-Erkennung (#305)
+_DEGREE_REQUIRED_PATTERNS = [
+    "abgeschlossenes studium",
+    "abgeschlossenes hochschulstudium",
+    "hochschulabschluss",
+    "universitaetsabschluss",
+    "universitätsabschluss",
+    "studienabschluss",
+    "akademischer abschluss",
+    "bachelor oder master",
+    "bachelor/master",
+    "master/bachelor",
+    "diplom oder master",
+    "diplom/master",
+    "bachelor of science",
+    "bachelor of engineering",
+    "bachelor of arts",
+    "master of science",
+    "master of engineering",
+    "master of arts",
+    "university degree",
+    "degree required",
+    "studium erforderlich",
+    "studium vorausgesetzt",
+    "studium im bereich",
+    "studium der informatik",
+    "studium der ingenieurwissenschaft",
+    "studium der wirtschaft",
+    "studium der betriebswirtschaft",
+    "studium des maschinenbau",
+    "studium in informatik",
+    "erfolgreich abgeschlossenes studium",
+]
+
+
+def _detect_degree_required(text: str) -> bool:
+    """Erkennt ob eine Stellenbeschreibung einen Hochschulabschluss fordert (#305)."""
+    text_lower = _normalize_for_matching(text)
+    return any(pat in text_lower for pat in _DEGREE_REQUIRED_PATTERNS)
+
+
+def _profile_has_degree(criteria: dict) -> bool:
+    """Prüft ob das Profil einen Hochschulabschluss enthält (#305)."""
+    education = criteria.get("_profile_education", [])
+    if not education:
+        return False
+    degree_keywords = {"bachelor", "master", "diplom", "magister", "doktor", "dr.",
+                       "phd", "mba", "staatsexamen", "promotion"}
+    for edu in education:
+        degree = (edu.get("degree") or "").lower()
+        if any(kw in degree for kw in degree_keywords):
+            return True
+        # Auch Studienfach prüfen — wenn degree leer, aber field_of_study "Informatik" o.ä.
+        field = (edu.get("field_of_study") or "").lower()
+        if field and ("studium" in degree or "university" in (edu.get("institution") or "").lower()
+                      or "hochschule" in (edu.get("institution") or "").lower()
+                      or "universität" in (edu.get("institution") or "").lower()):
+            return True
+    return False
 
 
 # Remote detection keywords

--- a/src/bewerbungs_assistent/tools/jobs.py
+++ b/src/bewerbungs_assistent/tools/jobs.py
@@ -121,6 +121,7 @@ def register(mcp, db, logger):
         "befristet",
         "bereits_beworben",
         "duplikat",
+        "kein_hochschulabschluss",
         "sonstiges",
     ]
 
@@ -185,6 +186,8 @@ def register(mcp, db, logger):
             return "zeitarbeit"
         if "befristet" in lower:
             return "befristet"
+        if "hochschul" in lower or "studium" in lower or "abschluss" in lower or "ats" in lower:
+            return "kein_hochschulabschluss"
         return reason
 
     def _auto_adjust_scoring(db_ref, reason: str, count: int) -> str | None:
@@ -719,6 +722,8 @@ def register(mcp, db, logger):
         if profile:
             skills = profile.get("skills", [])
             criteria["_profile_skills"] = [s.get("name", "").lower() for s in skills if s.get("name")]
+            # #305: Education für Hochschulabschluss-Erkennung
+            criteria["_profile_education"] = profile.get("education", [])
             prefs = profile.get("preferences", {})
             if prefs.get("min_gehalt"):
                 criteria["min_gehalt"] = prefs["min_gehalt"]

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -267,3 +267,71 @@ class TestBuildKeywords:
         # Indeed/Monster queries
         assert "PLM Consultant" in result["indeed_queries"]
         assert "Python" in result["monster_queries"]
+
+
+# === Hochschulabschluss-Erkennung (#305) ===
+
+class TestDegreeDetection:
+    """Fit-Analyse erkennt Hochschulabschluss-Anforderungen (#305)."""
+
+    def test_degree_required_detected(self):
+        """Stellenbeschreibung mit 'abgeschlossenes Studium' wird erkannt."""
+        from bewerbungs_assistent.job_scraper import _detect_degree_required
+        assert _detect_degree_required("Abgeschlossenes Studium im Bereich Informatik")
+        assert _detect_degree_required("Bachelor of Science required")
+        assert _detect_degree_required("Hochschulabschluss in Ingenieurwesen")
+
+    def test_degree_not_falsely_detected(self):
+        """Beschreibungen ohne Studium-Anforderung triggern keine Warnung."""
+        from bewerbungs_assistent.job_scraper import _detect_degree_required
+        assert not _detect_degree_required("10 Jahre Berufserfahrung im PLM-Umfeld")
+        assert not _detect_degree_required("Teamcenter Consultant gesucht")
+
+    def test_profile_has_degree(self):
+        """Profil mit Bachelor/Master wird korrekt erkannt."""
+        from bewerbungs_assistent.job_scraper import _profile_has_degree
+        assert _profile_has_degree({"_profile_education": [
+            {"degree": "Bachelor of Science", "field_of_study": "Informatik", "institution": "TU Hamburg"}
+        ]})
+        assert _profile_has_degree({"_profile_education": [
+            {"degree": "Master of Engineering", "field_of_study": "", "institution": ""}
+        ]})
+
+    def test_profile_without_degree(self):
+        """Profil ohne Studium wird korrekt erkannt."""
+        from bewerbungs_assistent.job_scraper import _profile_has_degree
+        assert not _profile_has_degree({"_profile_education": []})
+        assert not _profile_has_degree({})
+        assert not _profile_has_degree({"_profile_education": [
+            {"degree": "Ausbildung", "field_of_study": "Mechatronik", "institution": "IHK"}
+        ]})
+
+    def test_fit_analyse_degree_risk(self):
+        """Fit-Analyse erzeugt Risikowarnung wenn Studium gefordert aber fehlt."""
+        job = _job(
+            title="PLM Consultant",
+            description="Abgeschlossenes Studium im Bereich Ingenieurwesen. "
+                        "Erfahrung mit PLM/PDM-Systemen wie Teamcenter."
+        )
+        criteria = _criteria(muss=["PLM"])
+        criteria["_profile_education"] = []  # Kein Studium
+        result = fit_analyse(job, criteria)
+        assert result["hochschulabschluss_gefordert"] is True
+        assert any("HOCHSCHULABSCHLUSS" in r for r in result["risks"])
+        assert "Hochschulabschluss fehlt" in result["factors"]
+
+    def test_fit_analyse_no_risk_with_degree(self):
+        """Fit-Analyse erzeugt keine Warnung wenn Profil Studium enthält."""
+        job = _job(
+            title="PLM Consultant",
+            description="Abgeschlossenes Studium im Bereich Ingenieurwesen. "
+                        "Erfahrung mit PLM/PDM-Systemen wie Teamcenter."
+        )
+        criteria = _criteria(muss=["PLM"])
+        criteria["_profile_education"] = [
+            {"degree": "Diplom-Ingenieur", "field_of_study": "Maschinenbau",
+             "institution": "TU München"}
+        ]
+        result = fit_analyse(job, criteria)
+        assert result["hochschulabschluss_gefordert"] is True
+        assert not any("HOCHSCHULABSCHLUSS" in r for r in result["risks"])


### PR DESCRIPTION
## Summary
- Fit-Analyse erkennt jetzt Studiums-Anforderungen in Stellenbeschreibungen (30+ Signalwörter)
- Prüft automatisch ob Profil einen Hochschulabschluss enthält
- Bei Mismatch: Risikowarnung + Score-Malus (-2 Punkte)
- Neuer Ablehnungsgrund `kein_hochschulabschluss` mit Freitext-Normalisierung
- Dashboard-API `/api/jobs/{hash}/fit-analyse` liefert jetzt Education-Daten mit

## Test plan
- [ ] Stelle mit "Abgeschlossenes Studium" → Risikowarnung in Fit-Analyse
- [ ] Profil mit Bachelor → keine Warnung bei gleicher Stelle
- [ ] Profil ohne Studium → Warnung + neues Feld `hochschulabschluss_gefordert: true`
- [ ] 6 Unit-Tests bestanden (TestDegreeDetection)

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)