### PR TITLE
feat(frontend+api): Kalender-Seite mit ICS-Export (#310)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@
   AppWindow,
   BarChart3,
   BriefcaseBusiness,
+  CalendarDays,
   ChevronDown,
   Copy,
   Coffee,
@@ -29,6 +30,7 @@ import DashboardPage from "@/pages/DashboardPage";
 import JobsPage from "@/pages/JobsPage";
 import ProfilePage from "@/pages/ProfilePage";
 import SettingsPage from "@/pages/SettingsPage";
+import CalendarPage from "@/pages/CalendarPage";
 import StatsPage from "@/pages/StatsPage";
 import { cn, copyToClipboard, parsePageFromHash, resolveLegacyAction } from "@/utils";
 
@@ -57,6 +59,7 @@ const TAB_CONFIG = [
   { id: "profil", title: "Profil", icon: UserRound, defaultMeta: "Lebenslauf-Basis und Vollständigkeit" },
   { id: "stellen", title: "Stellen", icon: BriefcaseBusiness, defaultMeta: "Treffer, Filter und Fit" },
   { id: "bewerbungen", title: "Bewerbungen", icon: Send, defaultMeta: "TODOs, Follow-ups und Status" },
+  { id: "kalender", title: "Kalender", icon: CalendarDays, defaultMeta: "Termine und ICS-Export" },
   { id: "statistiken", title: "Statistiken", icon: BarChart3, defaultMeta: "Charts, Trends und Export" },
   { id: "einstellungen", title: "Einstellungen", icon: Settings2, defaultMeta: "Quellen, Suche und Verhalten" },
 ];
@@ -929,6 +932,7 @@ export default function App() {
           {page === "profil" ? <ProfilePage /> : null}
           {page === "stellen" ? <JobsPage /> : null}
           {page === "bewerbungen" ? <ApplicationsPage /> : null}
+          {page === "kalender" ? <CalendarPage /> : null}
           {page === "statistiken" ? <StatsPage /> : null}
           {page === "einstellungen" ? <SettingsPage /> : null}
         </main>

--- a/frontend/src/pages/CalendarPage.jsx
+++ b/frontend/src/pages/CalendarPage.jsx
@@ -1,0 +1,238 @@
+import { Calendar, CalendarClock, Clock, Download, ExternalLink, MapPin, Trash2, Video } from "lucide-react";
+import { useEffect, useEffectEvent, useState } from "react";
+
+import { api, apiUrl, deleteRequest } from "@/api";
+import { useApp } from "@/app-context";
+import {
+  Badge,
+  Button,
+  Card,
+  EmptyState,
+  LinkButton,
+  LoadingPanel,
+  PageHeader,
+} from "@/components/ui";
+import { cn, formatDate, formatDateTime } from "@/utils";
+
+const MEETING_TYPE_LABELS = {
+  interview: "Interview",
+  zweitgespraech: "2. Gespr\u00e4ch",
+  telefoninterview: "Telefoninterview",
+  assessment: "Assessment",
+  kennenlernen: "Kennenlernen",
+  sonstiges: "Termin",
+};
+
+function meetingTypeLabel(type) {
+  return MEETING_TYPE_LABELS[type] || type || "Termin";
+}
+
+function isPast(dateStr) {
+  if (!dateStr) return false;
+  return new Date(dateStr) < new Date();
+}
+
+function isToday(dateStr) {
+  if (!dateStr) return false;
+  const d = new Date(dateStr);
+  const now = new Date();
+  return d.toDateString() === now.toDateString();
+}
+
+export default function CalendarPage() {
+  const { reloadKey, pushToast } = useApp();
+  const [loading, setLoading] = useState(true);
+  const [meetings, setMeetings] = useState([]);
+  const [collisions, setCollisions] = useState([]);
+  const [filter, setFilter] = useState("upcoming"); // upcoming | past | all
+
+  const loadData = useEffectEvent(async () => {
+    try {
+      const data = await api("/api/meetings/calendar?days=365");
+      setMeetings(data?.meetings || []);
+      setCollisions(data?.collisions || []);
+    } catch (error) {
+      pushToast(`Termine konnten nicht geladen werden: ${error.message}`, "danger");
+    } finally {
+      setLoading(false);
+    }
+  });
+
+  useEffect(() => { loadData(); }, [reloadKey]);
+
+  async function deleteMeeting(id) {
+    try {
+      await deleteRequest(`/api/meetings/${id}`);
+      setMeetings((cur) => cur.filter((m) => m.id !== id));
+      pushToast("Termin gel\u00f6scht", "success");
+    } catch (error) {
+      pushToast(`Fehler: ${error.message}`, "danger");
+    }
+  }
+
+  const collisionIds = new Set(collisions.flatMap((c) => [c.meeting_1, c.meeting_2]));
+
+  const filtered = meetings.filter((m) => {
+    if (filter === "upcoming") return !isPast(m.meeting_date);
+    if (filter === "past") return isPast(m.meeting_date);
+    return true;
+  });
+
+  const grouped = {};
+  for (const m of filtered) {
+    const date = (m.meeting_date || "").slice(0, 10);
+    if (!grouped[date]) grouped[date] = [];
+    grouped[date].push(m);
+  }
+  const sortedDates = Object.keys(grouped).sort();
+
+  if (loading) return <LoadingPanel />;
+
+  return (
+    <div id="page-kalender" className="page active">
+      <div className="mb-6 flex flex-wrap items-baseline justify-between gap-4">
+        <PageHeader title="Kalender" subtitle={`${meetings.length} Termine`} />
+        <div className="flex flex-wrap items-center gap-2">
+          {[
+            { label: "Kommende", value: "upcoming" },
+            { label: "Vergangene", value: "past" },
+            { label: "Alle", value: "all" },
+          ].map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => setFilter(opt.value)}
+              className={`rounded-lg px-2.5 py-1 text-xs font-medium transition-colors ${
+                filter === opt.value
+                  ? "bg-sky/15 text-sky"
+                  : "text-muted/40 hover:text-ink hover:bg-white/[0.04]"
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+          <LinkButton
+            size="sm"
+            href={apiUrl("/api/meetings/export.ics")}
+            target="_blank"
+            rel="noreferrer"
+          >
+            <Download size={14} />
+            ICS Export
+          </LinkButton>
+        </div>
+      </div>
+
+      {filtered.length === 0 ? (
+        <EmptyState
+          title="Keine Termine"
+          description={filter === "upcoming"
+            ? "Keine kommenden Termine. Termine werden automatisch aus E-Mails und Bewerbungen erkannt."
+            : "Keine Termine im gew\u00e4hlten Zeitraum."
+          }
+        />
+      ) : (
+        <div className="grid gap-4">
+          {sortedDates.map((date) => (
+            <div key={date}>
+              <h2 className={cn(
+                "mb-2 text-sm font-semibold",
+                isToday(date) ? "text-sky" : isPast(date) ? "text-muted/40" : "text-ink"
+              )}>
+                {isToday(date) ? "Heute" : formatDate(date)}
+                {isToday(date) && <span className="ml-2 text-xs font-normal text-muted/50">({formatDate(date)})</span>}
+              </h2>
+              <div className="grid gap-2">
+                {grouped[date].map((meeting) => {
+                  const past = isPast(meeting.meeting_date);
+                  const hasCollision = collisionIds.has(meeting.id);
+                  return (
+                    <Card
+                      key={meeting.id}
+                      className={cn(
+                        "rounded-xl",
+                        past && "opacity-50",
+                        hasCollision && "border-amber/30 border"
+                      )}
+                    >
+                      <div className="flex items-start gap-3">
+                        <div className={cn(
+                          "mt-0.5 flex h-9 w-9 items-center justify-center rounded-lg shrink-0",
+                          past ? "bg-white/[0.03]" : "bg-sky/10"
+                        )}>
+                          <CalendarClock size={18} className={past ? "text-muted/30" : "text-sky"} />
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <h3 className="font-medium text-ink truncate">{meeting.title}</h3>
+                            <Badge tone={past ? "neutral" : "sky"}>{meetingTypeLabel(meeting.meeting_type)}</Badge>
+                            {hasCollision && <Badge tone="amber">Kollision</Badge>}
+                          </div>
+                          {(meeting.app_company || meeting.app_title) && (
+                            <p className="text-sm text-muted/50 mt-0.5 truncate">
+                              {meeting.app_title}{meeting.app_company ? ` \u2014 ${meeting.app_company}` : ""}
+                            </p>
+                          )}
+                          <div className="mt-1.5 flex flex-wrap items-center gap-3 text-xs text-muted/40">
+                            <span className="flex items-center gap-1">
+                              <Clock size={11} />
+                              {formatDateTime(meeting.meeting_date)}
+                              {meeting.meeting_end && ` \u2013 ${formatDateTime(meeting.meeting_end).split(", ").pop()}`}
+                            </span>
+                            {meeting.location && (
+                              <span className="flex items-center gap-1">
+                                <MapPin size={11} />
+                                {meeting.location}
+                              </span>
+                            )}
+                            {meeting.platform && (
+                              <span className="flex items-center gap-1">
+                                <Video size={11} />
+                                {meeting.platform}
+                              </span>
+                            )}
+                          </div>
+                          {meeting.notes && (
+                            <p className="mt-1.5 text-xs text-muted/40 line-clamp-2">{meeting.notes}</p>
+                          )}
+                        </div>
+                        <div className="flex shrink-0 items-center gap-1">
+                          {meeting.meeting_url && (
+                            <a
+                              href={meeting.meeting_url}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="rounded-lg p-1.5 text-muted/30 hover:text-sky transition-colors"
+                              title="Meeting-Link \u00f6ffnen"
+                            >
+                              <ExternalLink size={14} />
+                            </a>
+                          )}
+                          <a
+                            href={apiUrl(`/api/meetings/${meeting.id}/ics`)}
+                            className="rounded-lg p-1.5 text-muted/30 hover:text-teal transition-colors"
+                            title="ICS herunterladen"
+                          >
+                            <Download size={14} />
+                          </a>
+                          <button
+                            type="button"
+                            onClick={() => deleteMeeting(meeting.id)}
+                            className="rounded-lg p-1.5 text-muted/30 hover:text-coral transition-colors"
+                            title="Termin l\u00f6schen"
+                          >
+                            <Trash2 size={14} />
+                          </button>
+                        </div>
+                      </div>
+                    </Card>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -3,6 +3,7 @@
   "profil",
   "stellen",
   "bewerbungen",
+  "kalender",
   "statistiken",
   "einstellungen",
 ];

--- a/src/bewerbungs_assistent/dashboard.py
+++ b/src/bewerbungs_assistent/dashboard.py
@@ -2155,6 +2155,92 @@ async def api_meeting_ics(meeting_id: str):
     )
 
 
+@app.get("/api/meetings/export.ics")
+async def api_meetings_export_ics():
+    """Export all planned meetings as a single .ics calendar file (#310)."""
+    conn = _db.connect()
+    pid = _db.get_active_profile_id()
+    rows = conn.execute(
+        """SELECT m.*, a.title as app_title, a.company as app_company, a.id as app_id
+           FROM application_meetings m
+           LEFT JOIN applications a ON m.application_id = a.id
+           WHERE m.status='geplant'
+             AND (m.profile_id=? OR m.profile_id IS NULL)
+           ORDER BY m.meeting_date ASC""",
+        (pid,),
+    ).fetchall()
+
+    from datetime import datetime as _dt
+    now_stamp = _dt.now().strftime("%Y%m%dT%H%M%SZ")
+
+    def _fmt_dt(iso_str):
+        if not iso_str:
+            return None
+        try:
+            return _dt.fromisoformat(iso_str).strftime("%Y%m%dT%H%M%S")
+        except (ValueError, TypeError):
+            return None
+
+    ics_lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//PBP Bewerbungs-Assistent//DE",
+        "CALSCALE:GREGORIAN",
+        "METHOD:PUBLISH",
+        "X-WR-CALNAME:PBP Bewerbungstermine",
+    ]
+
+    for r in rows:
+        m = dict(r)
+        dt_start = _fmt_dt(m.get("meeting_date"))
+        if not dt_start:
+            continue
+        dt_end = _fmt_dt(m.get("meeting_end")) or dt_start
+        title = m.get("title", "Termin")
+        company = m.get("app_company", "")
+        app_title = m.get("app_title", "")
+        app_id = m.get("app_id", "")
+        location = m.get("location", "")
+        meeting_url = m.get("meeting_url", "")
+        notes = m.get("notes", "") or ""
+
+        desc_parts = []
+        if company and app_title:
+            desc_parts.append(f"Bewerbung: {app_title} bei {company}")
+        if app_id:
+            desc_parts.append(f"PBP-Link: http://localhost:8200/bewerbungen?id={app_id}")
+        if meeting_url:
+            desc_parts.append(f"Meeting-Link: {meeting_url}")
+        if notes:
+            desc_parts.append(f"Notizen: {notes}")
+
+        ics_lines.append("BEGIN:VEVENT")
+        ics_lines.append(f"UID:{m['id']}@pbp.local")
+        ics_lines.append(f"DTSTAMP:{now_stamp}")
+        ics_lines.append(f"DTSTART:{dt_start}")
+        ics_lines.append(f"DTEND:{dt_end}")
+        ics_lines.append(f"SUMMARY:{title}" + (f" — {company}" if company else ""))
+        desc_text = "\\n".join(desc_parts)
+        ics_lines.append(f"DESCRIPTION:{desc_text}")
+        if location:
+            ics_lines.append(f"LOCATION:{location}")
+        if meeting_url:
+            ics_lines.append(f"URL:{meeting_url}")
+        ics_lines.append("END:VEVENT")
+
+    ics_lines.append("END:VCALENDAR")
+    ics_content = "\r\n".join(ics_lines)
+
+    from starlette.responses import Response
+    return Response(
+        content=ics_content,
+        media_type="text/calendar",
+        headers={
+            "Content-Disposition": 'attachment; filename="pbp-termine.ics"',
+        },
+    )
+
+
 @app.get("/api/meetings/calendar")
 async def api_meetings_calendar(days: int = 90):
     """Get all meetings for calendar view with collision detection (#267)."""


### PR DESCRIPTION
## Summary
- Neue Kalender-Seite mit chronologischer Terminliste
- Filter: Kommende / Vergangene / Alle Termine  
- Kollisionserkennung (überlappende Termine amber markiert)
- ICS-Download pro Termin + Gesamt-Export Button
- Neuer API-Endpoint `GET /api/meetings/export.ics` für Bulk-Export
- Navigation: Kalender-Tab zwischen Bewerbungen und Statistiken

## Test plan
- [ ] Kalender-Seite über Navigation erreichbar
- [ ] Termine werden gruppiert nach Datum angezeigt
- [ ] Filter wechselt zwischen Kommende/Vergangene/Alle
- [ ] ICS Export Button generiert gültige .ics Datei
- [ ] Einzelner Termin-Download funktioniert
- [ ] Termin löschen entfernt aus Liste

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)