### PR TITLE
[codex] Fix beta.19 release blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,58 @@
 
 Alle wichtigen Änderungen am Bewerbungs-Assistent werden hier dokumentiert.
 
+## [1.5.0-beta.19] - 2026-04-10
+
+### Bug Fixes
+- Profil-Isolation fuer Dokument-Endpunkte gehaertet: Download, Typ-Aenderung, Relinking und Loeschen akzeptieren nur noch Dokumente aus dem aktiven Profil
+- Meeting-Endpunkte gegen profilfremde IDs abgesichert: Einzelansicht, ICS, Update, Delete und Bewerbungs-Meetingliste pruefen jetzt das aktive Profil
+- `create_backup()` erzeugt Sicherungen jetzt SQLite-/WAL-sicher ueber die Backup-API statt ueber eine nackte Dateikopie
+- `release_check.py` smoke-testet das Repo jetzt mit `src/` auf dem Python-Pfad und meldet Versions-/Changelog-Mismatches klarer
+
+### Qualitaet
+- Neue Regressionstests fuer Cross-Profile-Dokumente, Cross-Profile-Meetings, WAL-Backups und den Release-Gate
+
+## [1.5.0-beta.18] - 2026-04-09
+
+### Verbesserungen
+- 19 umgesetzte Issues fuer den Beta-Feinschliff rund um Dashboard, Dokumente, Kalender, Settings und Import-/Analyse-Flows
+
+## [1.5.0-beta.17] - 2026-04-09
+
+### Bug Fixes
+- Installer laedt Python erneut, wenn eine kopierte Installation defekt ist (#386)
+
+## [1.5.0-beta.16] - 2026-04-09
+
+### Bug Fixes
+- Installer korrigiert `_pth`-Konfiguration bei vorhandener Python-Installation (#386)
+
+## [1.5.0-beta.15] - 2026-04-09
+
+### Qualitaet
+- Clean-Release ohne ZIP-Asset fuer den Installer-/Release-Pfad
+
+## [1.5.0-beta.14] - 2026-04-09
+
+### Qualitaet
+- Release-Stand fuer `v1.5.0-beta.14` konsolidiert
+
+## [1.5.0-beta.13] - 2026-04-09
+
+### Neue Features
+- Dokument-Analyse-Status im Dashboard und Import-Flag fuer uebernommene Daten
+- Aktivitaetslog fuer neuere Workspace-Aktionen
+
+## [1.5.0-beta.12] - 2026-04-09
+
+### Verbesserungen
+- Dokumente loeschbar, Metrik-Perspektiven nachgeschaerft, Chrome-/Skill-/Settings-UX erweitert
+
+## [1.5.0-beta.11] - 2026-04-09
+
+### Bug Fixes
+- Dual-DB-Probleme, Kalender-Kantenfaelle, Umlaute, Antwortzeiten und `is_active`-Handling stabilisiert
+
 ## [1.5.0-beta.10] - 2026-04-08
 
 ### Verbesserungen

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Stable](https://img.shields.io/badge/Stable-v1.4.3-brightgreen.svg)](https://github.com/MadGapun/PBP/releases/latest)
 [![Beta](https://img.shields.io/badge/Beta-v1.5.0--beta-orange.svg)](https://github.com/MadGapun/PBP/releases)
-[![Tests](https://img.shields.io/badge/Tests-390-brightgreen.svg)](#tests)
+[![Tests](https://img.shields.io/badge/Tests-394-brightgreen.svg)](#tests)
 [![Tools](https://img.shields.io/badge/MCP_Tools-73-blueviolet.svg)](#mcp-schnittstelle)
 [![Workflows](https://img.shields.io/badge/Workflows-16-ff69b4.svg)](#die-16-workflows)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bewerbungs-assistent"
-version = "1.5.0-beta.10"
+version = "1.5.0-beta.19"
 description = "KI-gestützter Bewerbungsassistent — MCP Server für Claude Desktop"
 readme = {text = "KI-gestützter Bewerbungsassistent als MCP Server für Claude Desktop", content-type = "text/plain"}
 license = "MIT"

--- a/release_check.py
+++ b/release_check.py
@@ -82,20 +82,31 @@ def check_versions(fix=False):
         "CHANGELOG.md (top)": changelog_version,
     }
 
-    unique = set(v for v in versions.values() if v)
-    if len(unique) == 1:
-        ok(f"Alle Versionen konsistent: {unique.pop()}")
+    mismatches = []
+
+    if pyproject_version != init_version:
+        if fix and init_version:
+            content = pyproject_file.read_text(encoding="utf-8")
+            content = re.sub(r'^version = "[^"]+"', f'version = "{init_version}"', content, flags=re.MULTILINE)
+            pyproject_file.write_text(content, encoding="utf-8")
+            pyproject_version = init_version
+            versions["pyproject.toml"] = pyproject_version
+            ok(f"pyproject.toml auf {init_version} korrigiert")
+        else:
+            mismatches.append("pyproject.toml")
+
+    if changelog_version != init_version:
+        mismatches.append("CHANGELOG.md")
+
+    if not mismatches:
+        ok(f"Alle Versionen konsistent: {init_version}")
     else:
         for source, ver in versions.items():
             print(f"    {source}: {ver}")
-        if fix and init_version:
-            # Fix pyproject.toml
-            content = pyproject_file.read_text(encoding="utf-8")
-            content = re.sub(r'^version = "[^"]+"', f'version = "{init_version}"', content, flags=re.MULTILINE)
-            pyproject_file.write_text(content)
-            ok(f"pyproject.toml auf {init_version} korrigiert")
-        else:
-            error("Versionen sind inkonsistent! Nutze --fix oder korrigiere manuell.")
+        if "CHANGELOG.md" in mismatches:
+            error("CHANGELOG.md steht nicht auf dem aktuellen Release-Stand und muss manuell aktualisiert werden.")
+        if "pyproject.toml" in mismatches:
+            error("pyproject.toml steht nicht auf dem aktuellen Release-Stand.")
 
     return init_version
 
@@ -158,12 +169,17 @@ def check_first_run_smoke():
     print("\n[4/4] First-Run Smoke")
 
     try:
+        pythonpath = str(PROJECT_DIR / "src")
+        existing_pythonpath = os.environ.get("PYTHONPATH")
+        if existing_pythonpath:
+            pythonpath = pythonpath + os.pathsep + existing_pythonpath
         result = subprocess.run(
             [sys.executable, "-c", """
 import tempfile, os, shutil, sys
 d = tempfile.mkdtemp()
 try:
     os.environ['BA_DATA_DIR'] = d
+    sys.path.insert(0, os.path.join(os.getcwd(), 'src'))
     from bewerbungs_assistent.database import Database
     from bewerbungs_assistent.heartbeat import get_connection_status
     from bewerbungs_assistent.server import mcp
@@ -186,7 +202,7 @@ finally:
 """],
             capture_output=True, text=True, timeout=30,
             cwd=str(PROJECT_DIR),
-            env={**os.environ, "PYTHONIOENCODING": "utf-8"},
+            env={**os.environ, "PYTHONIOENCODING": "utf-8", "PYTHONPATH": pythonpath},
         )
         if "OK" in result.stdout:
             ok("First-Run Smoke bestanden (Profil + Heartbeat + Dashboard)")

--- a/src/bewerbungs_assistent/__init__.py
+++ b/src/bewerbungs_assistent/__init__.py
@@ -1,6 +1,6 @@
 """Bewerbungs-Assistent - KI-gestützter MCP Server für Claude Desktop."""
 
-__version__ = "1.5.0-beta.18"
+__version__ = "1.5.0-beta.19"
 
 
 def main():

--- a/src/bewerbungs_assistent/dashboard.py
+++ b/src/bewerbungs_assistent/dashboard.py
@@ -235,6 +235,38 @@ def _build_live_update_token_payload() -> dict:
     }
 
 
+def _get_active_profile_id() -> str | None:
+    """Return the current active profile id for profile-scoped API guards."""
+    return _db.get_active_profile_id() if _db else None
+
+
+def _get_application_row_for_active_profile(app_id: str):
+    """Fetch an application only if it belongs to the active profile."""
+    profile_id = _get_active_profile_id()
+    if not profile_id:
+        return None
+    conn = _db.connect()
+    return conn.execute(
+        "SELECT * FROM applications WHERE id=? AND (profile_id=? OR profile_id IS NULL)",
+        (app_id, profile_id),
+    ).fetchone()
+
+
+def _get_meeting_row_for_active_profile(meeting_id: str):
+    """Fetch a meeting with application metadata, scoped to the active profile."""
+    profile_id = _get_active_profile_id()
+    if not profile_id:
+        return None
+    conn = _db.connect()
+    return conn.execute(
+        """SELECT m.*, a.title as app_title, a.company as app_company, a.id as app_id
+           FROM application_meetings m
+           LEFT JOIN applications a ON m.application_id = a.id
+           WHERE m.id=? AND (m.profile_id=? OR m.profile_id IS NULL)""",
+        (meeting_id, profile_id),
+    ).fetchone()
+
+
 # === API Endpoints ===
 
 @app.get("/api/status")
@@ -554,7 +586,11 @@ async def api_delete_skill(skill_id: str):
 
 @app.delete("/api/document/{doc_id}")
 async def api_delete_document(doc_id: str):
-    _db.delete_document(doc_id)
+    profile_id = _get_active_profile_id()
+    if not profile_id:
+        return JSONResponse({"error": "Dokument nicht gefunden"}, status_code=404)
+    if not _db.delete_document(doc_id, profile_id=profile_id):
+        return JSONResponse({"error": "Dokument nicht gefunden"}, status_code=404)
     return {"status": "ok"}
 
 
@@ -562,9 +598,11 @@ async def api_delete_document(doc_id: str):
 async def api_update_document_type(doc_id: str, request: Request):
     data = await request.json()
     new_type = data.get("doc_type", "sonstiges")
-    conn = _db.connect()
-    conn.execute("UPDATE documents SET doc_type=? WHERE id=?", (new_type, doc_id))
-    conn.commit()
+    profile_id = _get_active_profile_id()
+    if not profile_id:
+        return JSONResponse({"error": "Dokument nicht gefunden"}, status_code=404)
+    if not _db.update_document_type(doc_id, new_type, profile_id=profile_id):
+        return JSONResponse({"error": "Dokument nicht gefunden"}, status_code=404)
     return {"status": "ok"}
 
 
@@ -573,14 +611,11 @@ async def api_link_document(doc_id: str, request: Request):
     """Change or remove document-application link (#366)."""
     data = await request.json()
     app_id = data.get("application_id") or None
-    conn = _db.connect()
-    pid = _db.get_active_profile_id()
-    # Verify document belongs to active profile
-    doc = conn.execute("SELECT id FROM documents WHERE id=? AND (profile_id=? OR profile_id IS NULL)", (doc_id, pid)).fetchone()
-    if not doc:
+    profile_id = _get_active_profile_id()
+    if not profile_id:
         return JSONResponse({"error": "Dokument nicht gefunden"}, status_code=404)
-    conn.execute("UPDATE documents SET linked_application_id=? WHERE id=?", (app_id, doc_id))
-    conn.commit()
+    if not _db.relink_document(doc_id, app_id, profile_id=profile_id):
+        return JSONResponse({"error": "Dokument oder Bewerbung nicht gefunden"}, status_code=404)
     return {"status": "ok"}
 
 
@@ -1586,7 +1621,9 @@ async def api_link_document(app_id: str, request: Request):
     doc_id = data.get("document_id")
     if not doc_id:
         return JSONResponse({"error": "document_id ist Pflicht"}, status_code=400)
-    _db.link_document_to_application(doc_id, app_id)
+    profile_id = _get_active_profile_id()
+    if not profile_id or not _db.link_document_to_application(doc_id, app_id, profile_id=profile_id):
+        return JSONResponse({"error": "Dokument oder Bewerbung nicht gefunden"}, status_code=404)
     return {"status": "ok"}
 
 
@@ -1838,8 +1875,10 @@ async def api_documents(
 @app.get("/api/documents/{doc_id}/download")
 async def api_download_document(doc_id: str):
     """Download/preview a document by ID."""
-    conn = _db.connect()
-    row = conn.execute("SELECT filename, filepath FROM documents WHERE id=?", (doc_id,)).fetchone()
+    profile_id = _get_active_profile_id()
+    if not profile_id:
+        return JSONResponse({"error": "Dokument nicht gefunden"}, status_code=404)
+    row = _db.get_document(doc_id, profile_id=profile_id)
     if not row:
         return JSONResponse({"error": "Dokument nicht gefunden"}, status_code=404)
     filepath = Path(row["filepath"])
@@ -2513,14 +2552,7 @@ async def api_activity_log(days: int = 90, categories: str = ""):
 @app.get("/api/meetings/{meeting_id}")
 async def api_get_meeting(meeting_id: str):
     """Get a single meeting."""
-    conn = _db.connect()
-    row = conn.execute(
-        """SELECT m.*, a.title as app_title, a.company as app_company
-           FROM application_meetings m
-           LEFT JOIN applications a ON m.application_id = a.id
-           WHERE m.id=?""",
-        (meeting_id,),
-    ).fetchone()
+    row = _get_meeting_row_for_active_profile(meeting_id)
     if not row:
         return JSONResponse({"error": "Termin nicht gefunden"}, status_code=404)
     return dict(row)
@@ -2530,14 +2562,22 @@ async def api_get_meeting(meeting_id: str):
 async def api_update_meeting(meeting_id: str, request: Request):
     """Update a meeting."""
     data = await request.json()
-    _db.update_meeting(meeting_id, data)
+    profile_id = _get_active_profile_id()
+    if not profile_id:
+        return JSONResponse({"error": "Termin nicht gefunden"}, status_code=404)
+    if not _db.update_meeting(meeting_id, data, profile_id=profile_id):
+        return JSONResponse({"error": "Termin nicht gefunden"}, status_code=404)
     return {"status": "ok"}
 
 
 @app.delete("/api/meetings/{meeting_id}")
 async def api_delete_meeting(meeting_id: str):
     """Cancel/delete a meeting."""
-    _db.delete_meeting(meeting_id)
+    profile_id = _get_active_profile_id()
+    if not profile_id:
+        return JSONResponse({"error": "Termin nicht gefunden"}, status_code=404)
+    if not _db.delete_meeting(meeting_id, profile_id=profile_id):
+        return JSONResponse({"error": "Termin nicht gefunden"}, status_code=404)
     return {"status": "ok"}
 
 
@@ -2552,6 +2592,8 @@ async def api_create_meeting(request: Request):
             {"error": "meeting_date ist erforderlich"},
             status_code=400,
         )
+    if app_id and not _get_application_row_for_active_profile(app_id):
+        return JSONResponse({"error": "Bewerbung nicht gefunden"}, status_code=404)
     mid = _db.add_meeting({
         "application_id": app_id or None,
         "title": data.get("title", "Termin"),
@@ -2572,21 +2614,17 @@ async def api_create_meeting(request: Request):
 @app.get("/api/applications/{app_id}/meetings")
 async def api_get_application_meetings(app_id: str):
     """List all meetings for a specific application."""
-    meetings = _db.get_meetings_for_application(app_id)
+    profile_id = _get_active_profile_id()
+    if not _get_application_row_for_active_profile(app_id):
+        return JSONResponse({"error": "Bewerbung nicht gefunden"}, status_code=404)
+    meetings = _db.get_meetings_for_application(app_id, profile_id=profile_id)
     return {"meetings": meetings, "count": len(meetings)}
 
 
 @app.get("/api/meetings/{meeting_id}/ics")
 async def api_meeting_ics(meeting_id: str):
     """Export a single meeting as .ics file (#261, #263)."""
-    conn = _db.connect()
-    row = conn.execute(
-        """SELECT m.*, a.title as app_title, a.company as app_company, a.id as app_id
-           FROM application_meetings m
-           LEFT JOIN applications a ON m.application_id = a.id
-           WHERE m.id=?""",
-        (meeting_id,),
-    ).fetchone()
+    row = _get_meeting_row_for_active_profile(meeting_id)
     if not row:
         return JSONResponse({"error": "Meeting nicht gefunden"}, status_code=404)
 

--- a/src/bewerbungs_assistent/database.py
+++ b/src/bewerbungs_assistent/database.py
@@ -101,7 +101,14 @@ def create_backup(db_path: Path, backup_dir: Path, max_backups: int = 5) -> Opti
     backup_dir.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     backup_path = backup_dir / f"pbp-backup-{timestamp}.db"
-    shutil.copy2(str(db_path), str(backup_path))
+    src = sqlite3.connect(str(db_path))
+    dst = sqlite3.connect(str(backup_path))
+    try:
+        src.execute("PRAGMA busy_timeout=5000")
+        src.backup(dst)
+    finally:
+        dst.close()
+        src.close()
     logger.info("Backup erstellt: %s", backup_path)
     # Rotate: keep only the newest max_backups
     backups = sorted(backup_dir.glob("pbp-backup-*.db"), key=lambda p: p.stat().st_mtime)
@@ -1502,6 +1509,17 @@ class Database:
                ORDER BY d.created_at DESC"""
         ).fetchall()]
 
+    def get_document(self, doc_id: str, profile_id: str = None) -> dict | None:
+        """Get a single document, optionally scoped to a profile."""
+        conn = self.connect()
+        query = "SELECT * FROM documents WHERE id=?"
+        params: list[str] = [str(doc_id)]
+        if profile_id is not None:
+            query += " AND (profile_id=? OR profile_id IS NULL)"
+            params.append(profile_id)
+        row = conn.execute(query, params).fetchone()
+        return dict(row) if row else None
+
     def add_document(self, data: dict) -> str:
         conn = self.connect()
         did = _gen_id()
@@ -1530,17 +1548,58 @@ class Database:
 
         return did
 
-    def delete_document(self, doc_id: str):
+    def update_document_type(self, doc_id: str, doc_type: str, profile_id: str = None) -> bool:
+        """Update a document type, optionally scoped to a profile."""
         conn = self.connect()
-        # Get filepath to delete file from disk
-        row = conn.execute("SELECT filepath FROM documents WHERE id = ?", (doc_id,)).fetchone()
-        if row and row["filepath"]:
+        query = "UPDATE documents SET doc_type=? WHERE id=?"
+        params: list[str] = [doc_type, str(doc_id)]
+        if profile_id is not None:
+            query += " AND (profile_id=? OR profile_id IS NULL)"
+            params.append(profile_id)
+        cur = conn.execute(query, params)
+        conn.commit()
+        return cur.rowcount > 0
+
+    def relink_document(self, doc_id: str, application_id: str | None, profile_id: str = None) -> bool:
+        """Relink or unlink a document, optionally scoped to a profile."""
+        conn = self.connect()
+        if not self.get_document(doc_id, profile_id=profile_id):
+            return False
+        if application_id is not None:
+            query = "SELECT 1 FROM applications WHERE id=?"
+            params: list[str] = [str(application_id)]
+            if profile_id is not None:
+                query += " AND (profile_id=? OR profile_id IS NULL)"
+                params.append(profile_id)
+            if not conn.execute(query, params).fetchone():
+                return False
+        query = "UPDATE documents SET linked_application_id=? WHERE id=?"
+        params = [application_id, str(doc_id)]
+        if profile_id is not None:
+            query += " AND (profile_id=? OR profile_id IS NULL)"
+            params.append(profile_id)
+        cur = conn.execute(query, params)
+        conn.commit()
+        return cur.rowcount > 0
+
+    def delete_document(self, doc_id: str, profile_id: str = None) -> bool:
+        conn = self.connect()
+        row = self.get_document(doc_id, profile_id=profile_id)
+        if not row:
+            return False
+        if row["filepath"]:
             try:
                 Path(row["filepath"]).unlink(missing_ok=True)
             except Exception as e:
                 logger.warning("Dokument-Datei konnte nicht gelöscht werden: %s", e)
-        conn.execute("DELETE FROM documents WHERE id = ?", (doc_id,))
+        query = "DELETE FROM documents WHERE id = ?"
+        params: list[str] = [str(doc_id)]
+        if profile_id is not None:
+            query += " AND (profile_id=? OR profile_id IS NULL)"
+            params.append(profile_id)
+        cur = conn.execute(query, params)
         conn.commit()
+        return cur.rowcount > 0
 
     def _auto_link_documents(self, application_id: str, company: str):
         """Auto-link unlinked documents whose filename contains the company name."""
@@ -1706,31 +1765,52 @@ class Database:
 
         return result
 
-    def link_document_to_application(self, doc_id, application_id: int):
+    def link_document_to_application(self, doc_id, application_id: int, profile_id: str = None) -> bool:
         """Link a document to an application and create timeline entry (#176, #219)."""
         conn = self.connect()
-        conn.execute(
+        doc_row = self.get_document(str(doc_id), profile_id=profile_id)
+        if not doc_row:
+            return False
+        app_query = "SELECT 1 FROM applications WHERE id=?"
+        app_params: list[str] = [str(application_id)]
+        if profile_id is not None:
+            app_query += " AND (profile_id=? OR profile_id IS NULL)"
+            app_params.append(profile_id)
+        if not conn.execute(app_query, app_params).fetchone():
+            return False
+        update_query = (
             "UPDATE documents SET linked_application_id=?, "
-            "extraction_status='angewendet', last_extraction_at=? WHERE id=?",
-            (application_id, _now(), str(doc_id)),
+            "extraction_status='angewendet', last_extraction_at=? WHERE id=?"
         )
+        update_params: list[str] = [application_id, _now(), str(doc_id)]
+        if profile_id is not None:
+            update_query += " AND (profile_id=? OR profile_id IS NULL)"
+            update_params.append(profile_id)
+        cur = conn.execute(update_query, update_params)
+        if cur.rowcount == 0:
+            return False
         # Get filename for timeline entry (#176)
-        doc_row = conn.execute("SELECT filename FROM documents WHERE id=?", (str(doc_id),)).fetchone()
         filename = doc_row["filename"] if doc_row else "Dokument"
         conn.execute("""
             INSERT INTO application_events (application_id, status, event_date, notes)
             VALUES (?, 'dokument', ?, ?)
         """, (str(application_id), _now(), f"Dokument verknuepft: {filename}"))
         conn.commit()
+        return True
 
-    def get_documents_for_application(self, application_id: str) -> list:
+    def get_documents_for_application(self, application_id: str, profile_id: str = None) -> list:
         """Return all documents linked to an application."""
         conn = self.connect()
-        return [dict(r) for r in conn.execute(
+        query = (
             "SELECT id, filename, filepath, doc_type, created_at, extraction_status "
-            "FROM documents WHERE linked_application_id=? ORDER BY created_at DESC",
-            (application_id,)
-        ).fetchall()]
+            "FROM documents WHERE linked_application_id=?"
+        )
+        params: list[str] = [application_id]
+        if profile_id is not None:
+            query += " AND (profile_id=? OR profile_id IS NULL)"
+            params.append(profile_id)
+        query += " ORDER BY created_at DESC"
+        return [dict(r) for r in conn.execute(query, params).fetchall()]
 
     # === Jobs ===
 
@@ -3665,17 +3745,19 @@ class Database:
         ).fetchall()
         return [dict(r) for r in rows]
 
-    def get_meetings_for_application(self, application_id: str) -> list:
+    def get_meetings_for_application(self, application_id: str, profile_id: str = None) -> list:
         """Get all meetings for a specific application."""
         conn = self.connect()
-        rows = conn.execute(
-            """SELECT * FROM application_meetings
-               WHERE application_id=? ORDER BY meeting_date ASC""",
-            (application_id,),
-        ).fetchall()
+        query = "SELECT * FROM application_meetings WHERE application_id=?"
+        params: list[str] = [application_id]
+        if profile_id is not None:
+            query += " AND (profile_id=? OR profile_id IS NULL)"
+            params.append(profile_id)
+        query += " ORDER BY meeting_date ASC"
+        rows = conn.execute(query, params).fetchall()
         return [dict(r) for r in rows]
 
-    def update_meeting(self, meeting_id: str, data: dict):
+    def update_meeting(self, meeting_id: str, data: dict, profile_id: str = None) -> bool:
         """Update meeting fields."""
         conn = self.connect()
         allowed = {"title", "meeting_date", "meeting_end", "location",
@@ -3686,19 +3768,28 @@ class Database:
             if k in allowed:
                 sets.append(f"{k}=?")
                 vals.append(v)
-        if sets:
-            vals.append(meeting_id)
-            conn.execute(
-                f"UPDATE application_meetings SET {', '.join(sets)} WHERE id=?",
-                vals,
-            )
-            conn.commit()
+        if not sets:
+            return False
+        query = f"UPDATE application_meetings SET {', '.join(sets)} WHERE id=?"
+        vals.append(meeting_id)
+        if profile_id is not None:
+            query += " AND (profile_id=? OR profile_id IS NULL)"
+            vals.append(profile_id)
+        cur = conn.execute(query, vals)
+        conn.commit()
+        return cur.rowcount > 0
 
-    def delete_meeting(self, meeting_id: str):
+    def delete_meeting(self, meeting_id: str, profile_id: str = None) -> bool:
         """Delete a meeting."""
         conn = self.connect()
-        conn.execute("DELETE FROM application_meetings WHERE id=?", (meeting_id,))
+        query = "DELETE FROM application_meetings WHERE id=?"
+        params: list[str] = [meeting_id]
+        if profile_id is not None:
+            query += " AND (profile_id=? OR profile_id IS NULL)"
+            params.append(profile_id)
+        cur = conn.execute(query, params)
         conn.commit()
+        return cur.rowcount > 0
 
 
 def _safe_float(val, default=None):

--- a/src/bewerbungs_assistent/tools/analyse.py
+++ b/src/bewerbungs_assistent/tools/analyse.py
@@ -543,7 +543,8 @@ def register(mcp, db, logger):
         if not doc:
             return {"fehler": "Dokument nicht gefunden. Prüfe die ID mit dokumente_zur_analyse()."}
 
-        db.link_document_to_application(dokument_id, bewerbung_id)
+        if not db.link_document_to_application(dokument_id, bewerbung_id, profile_id=db.get_active_profile_id()):
+            return {"fehler": "Dokument oder Bewerbung gehoeren nicht zum aktiven Profil."}
         return {
             "status": "verknuepft",
             "dokument": doc["filename"],

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -691,6 +691,119 @@ class TestApplicationDetail:
         assert r.status_code == 200
         assert len(r.json()["documents"]) == 2
 
+    def test_document_endpoints_reject_cross_profile_access(self, client, tmp_path):
+        """Dokument-Endpunkte duerfen keine fremden Profile lesen, aendern oder loeschen."""
+        import bewerbungs_assistent.dashboard as dash
+
+        pid_a = dash._db.create_profile("Profil A", "a@example.com")
+        app_a = dash._db.add_application({"title": "Job A", "company": "Firma A"})
+        doc_a_path = tmp_path / "profil-a.pdf"
+        doc_a_path.write_text("A", encoding="utf-8")
+        doc_a = dash._db.add_document({
+            "filename": "profil-a.pdf",
+            "filepath": str(doc_a_path),
+            "doc_type": "lebenslauf",
+        })
+
+        pid_b = dash._db.create_profile("Profil B", "b@example.com")
+        dash._db.switch_profile(pid_b)
+        app_b = dash._db.add_application({"title": "Job B", "company": "Firma B"})
+        doc_b_path = tmp_path / "profil-b.pdf"
+        doc_b_path.write_text("B", encoding="utf-8")
+        doc_b = dash._db.add_document({
+            "filename": "profil-b.pdf",
+            "filepath": str(doc_b_path),
+            "doc_type": "lebenslauf",
+        })
+
+        dash._db.switch_profile(pid_a)
+
+        relink = client.put(f"/api/document/{doc_a}/link", json={"application_id": app_b})
+        assert relink.status_code == 404
+        assert dash._db.get_document(doc_a, profile_id=pid_a)["linked_application_id"] is None
+
+        update_type = client.put(f"/api/document/{doc_b}/doc-type", json={"doc_type": "zeugnis"})
+        assert update_type.status_code == 404
+        assert dash._db.get_document(doc_b, profile_id=pid_b)["doc_type"] == "lebenslauf"
+
+        download = client.get(f"/api/documents/{doc_b}/download")
+        assert download.status_code == 404
+
+        delete = client.delete(f"/api/document/{doc_b}")
+        assert delete.status_code == 404
+        assert dash._db.get_document(doc_b, profile_id=pid_b) is not None
+
+        link_to_foreign_app = client.post(
+            f"/api/applications/{app_b}/link-document",
+            json={"document_id": doc_a},
+        )
+        assert link_to_foreign_app.status_code == 404
+        assert dash._db.get_document(doc_a, profile_id=pid_a)["linked_application_id"] is None
+
+        # Sanity check: same-profile link still works.
+        link_same_profile = client.post(
+            f"/api/applications/{app_a}/link-document",
+            json={"document_id": doc_a},
+        )
+        assert link_same_profile.status_code == 200
+        assert dash._db.get_document(doc_a, profile_id=pid_a)["linked_application_id"] == app_a
+
+    def test_meeting_endpoints_reject_cross_profile_access(self, client):
+        """Meeting-Endpunkte duerfen keine fremden Profile lesen oder veraendern."""
+        import bewerbungs_assistent.dashboard as dash
+
+        pid_a = dash._db.create_profile("Profil A", "a@example.com")
+        app_a = dash._db.add_application({"title": "Job A", "company": "Firma A"})
+
+        pid_b = dash._db.create_profile("Profil B", "b@example.com")
+        dash._db.switch_profile(pid_b)
+        app_b = dash._db.add_application({"title": "Job B", "company": "Firma B"})
+        meeting_b = dash._db.add_meeting({
+            "application_id": app_b,
+            "title": "B Termin",
+            "meeting_date": (datetime.now() + timedelta(days=3)).isoformat(),
+        })
+
+        dash._db.switch_profile(pid_a)
+
+        get_meeting = client.get(f"/api/meetings/{meeting_b}")
+        assert get_meeting.status_code == 404
+
+        update_meeting = client.put(f"/api/meetings/{meeting_b}", json={"title": "Manipuliert"})
+        assert update_meeting.status_code == 404
+        foreign_meeting = dash._db.get_meetings_for_application(app_b, profile_id=pid_b)[0]
+        assert foreign_meeting["title"] == "B Termin"
+
+        delete_meeting = client.delete(f"/api/meetings/{meeting_b}")
+        assert delete_meeting.status_code == 404
+        assert len(dash._db.get_meetings_for_application(app_b, profile_id=pid_b)) == 1
+
+        meeting_ics = client.get(f"/api/meetings/{meeting_b}/ics")
+        assert meeting_ics.status_code == 404
+
+        app_meetings = client.get(f"/api/applications/{app_b}/meetings")
+        assert app_meetings.status_code == 404
+
+        create_foreign = client.post(
+            "/api/meetings",
+            json={
+                "application_id": app_b,
+                "title": "Fremdtermin",
+                "meeting_date": (datetime.now() + timedelta(days=7)).isoformat(),
+            },
+        )
+        assert create_foreign.status_code == 404
+
+        create_same = client.post(
+            "/api/meetings",
+            json={
+                "application_id": app_a,
+                "title": "Eigenes Meeting",
+                "meeting_date": (datetime.now() + timedelta(days=2)).isoformat(),
+            },
+        )
+        assert create_same.status_code == 200
+
 
 # ============================================================
 # Gespraechsnotizen

--- a/tests/test_release_hygiene.py
+++ b/tests/test_release_hygiene.py
@@ -1,0 +1,52 @@
+"""Release-Hygiene-Regressionstests fuer Backups und Release-Gate."""
+
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+from bewerbungs_assistent.database import create_backup
+
+
+def test_create_backup_captures_wal_changes(tmp_path):
+    """Backups muessen auch im WAL-Modus eine lesbare, vollstaendige DB erzeugen."""
+    db_path = tmp_path / "wal-test.db"
+    backup_dir = tmp_path / "backups"
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("CREATE TABLE demo (id INTEGER PRIMARY KEY, value TEXT)")
+        conn.commit()
+        conn.execute("INSERT INTO demo(value) VALUES ('persisted')")
+        conn.commit()
+        conn.execute("INSERT INTO demo(value) VALUES ('only_in_wal')")
+        conn.commit()
+
+        backup_path = create_backup(db_path, backup_dir)
+    finally:
+        conn.close()
+
+    assert backup_path is not None
+
+    backup_conn = sqlite3.connect(str(backup_path))
+    try:
+        rows = [row[0] for row in backup_conn.execute("SELECT value FROM demo ORDER BY id").fetchall()]
+    finally:
+        backup_conn.close()
+
+    assert rows == ["persisted", "only_in_wal"]
+
+
+def test_release_check_script_passes():
+    """Der Release-Gate muss auf dem aktuellen Checkout gruene Ergebnisse liefern."""
+    repo_root = Path(__file__).resolve().parent.parent
+    result = subprocess.run(
+        [sys.executable, "release_check.py"],
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+    assert result.returncode == 0, result.stdout + "\n" + result.stderr


### PR DESCRIPTION
## Was sich aendert
- haertet profilgescopte Dokument-Endpunkte gegen Cross-Profile-Download, -Relink, -Typaenderung und -Loeschen ab
- haertet Meeting-Endpunkte gegen profilfremde IDs ab, inklusive Einzelansicht, ICS, Update, Delete und Bewerbungs-Meetingliste
- stellt `create_backup()` auf die SQLite-Backup-API um, damit WAL-Daten konsistent gesichert werden
- bringt Release-Hygiene fuer `1.5.0-beta.19` in Ordnung: Versionen, Changelog, README-Badge und `release_check.py`
- ergaenzt Regressionstests fuer die beiden Profil-Isolationsluecken, WAL-Backups und den Release-Gate

## Warum
Die QA auf `v1.5.0-beta.18` hat vier Release-Blocker gezeigt:
- Dokument-API akzeptierte profilfremde IDs und konnte sogar in Bewerbungen anderer Profile relinken
- Meeting-API ignorierte das aktive Profil bei Lesen, Aendern, Loeschen und Einzel-ICS
- `create_backup()` erzeugte im WAL-Modus keine verlaessliche Sicherung
- Release-Artefakte und Release-Check waren fuer den RC nicht konsistent genug

## Wirkung
- Multi-Profil-Grenzen werden auf den betroffenen Dashboard-Routen jetzt tatsaechlich erzwungen
- Migrations-/Schema-Backups sind im WAL-Modus wieder als Rueckfall nutzbar
- `release_check.py` ist wieder ein vernuenftiger Go/No-Go-Gate fuer den naechsten Beta-/Release-Stand

## Validierung
- `python -m pytest tests/ -q`
- `python release_check.py`
- `pnpm run build`

Closes #406
Closes #407
Closes #408
Closes #409