### PR TITLE
Fix beta.20 application and email profile guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Alle wichtigen Änderungen am Bewerbungs-Assistent werden hier dokumentiert.
 
+## [1.5.0-beta.20] - 2026-04-10
+
+### Bug Fixes
+- Weitere Application-/Email-Endpunkte gegen profilfremde IDs abgesichert: Timeline, Print, Status, Notes, Snapshot, Fit-Analyse, E-Mail-Details, E-Mail-Loeschen, Match-Bestaetigung und Status-Uebernahme pruefen jetzt aktives Profil und aktive Bewerbung
+- Bewerbungsbearbeitung schreibt Timeline-Eintraege wieder schema-konform ohne String-ID und liefert bei echten Aenderungen keinen `datatype mismatch`-500er mehr
+
+### Qualitaet
+- Regressionstests fuer Cross-Profile-Bewerbungen/E-Mails sowie Same-Profile-Bearbeitung und E-Mail-Aktionen ergaenzt
+
 ## [1.5.0-beta.19] - 2026-04-10
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Stable](https://img.shields.io/badge/Stable-v1.4.3-brightgreen.svg)](https://github.com/MadGapun/PBP/releases/latest)
 [![Beta](https://img.shields.io/badge/Beta-v1.5.0--beta-orange.svg)](https://github.com/MadGapun/PBP/releases)
-[![Tests](https://img.shields.io/badge/Tests-394-brightgreen.svg)](#tests)
+[![Tests](https://img.shields.io/badge/Tests-396-brightgreen.svg)](#tests)
 [![Tools](https://img.shields.io/badge/MCP_Tools-73-blueviolet.svg)](#mcp-schnittstelle)
 [![Workflows](https://img.shields.io/badge/Workflows-16-ff69b4.svg)](#die-16-workflows)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bewerbungs-assistent"
-version = "1.5.0-beta.19"
+version = "1.5.0-beta.20"
 description = "KI-gestützter Bewerbungsassistent — MCP Server für Claude Desktop"
 readme = {text = "KI-gestützter Bewerbungsassistent als MCP Server für Claude Desktop", content-type = "text/plain"}
 license = "MIT"

--- a/src/bewerbungs_assistent/__init__.py
+++ b/src/bewerbungs_assistent/__init__.py
@@ -1,6 +1,6 @@
 """Bewerbungs-Assistent - KI-gestützter MCP Server für Claude Desktop."""
 
-__version__ = "1.5.0-beta.19"
+__version__ = "1.5.0-beta.20"
 
 
 def main():

--- a/src/bewerbungs_assistent/dashboard.py
+++ b/src/bewerbungs_assistent/dashboard.py
@@ -267,6 +267,14 @@ def _get_meeting_row_for_active_profile(meeting_id: str):
     ).fetchone()
 
 
+def _get_email_for_active_profile(email_id: str):
+    """Fetch an email only if it belongs to the active profile."""
+    profile_id = _get_active_profile_id()
+    if not profile_id:
+        return None
+    return _db.get_email(email_id, profile_id=profile_id) if _db else None
+
+
 # === API Endpoints ===
 
 @app.get("/api/status")
@@ -1289,14 +1297,15 @@ async def api_generate_cv(format: str = "text"):
 @app.get("/api/application/{app_id}/timeline")
 async def api_application_timeline(app_id: str):
     """Get full event timeline for an application with job details and documents."""
+    profile_id = _get_active_profile_id()
+    app_row = _get_application_row_for_active_profile(app_id)
+    if not profile_id or not app_row:
+        return JSONResponse({"error": "Bewerbung nicht gefunden"}, status_code=404)
     conn = _db.connect()
     events = [dict(r) for r in conn.execute(
         "SELECT * FROM application_events WHERE application_id = ? ORDER BY event_date DESC",
         (app_id,)
     ).fetchall()]
-    app_row = conn.execute("SELECT * FROM applications WHERE id = ?", (app_id,)).fetchone()
-    if not app_row:
-        return JSONResponse({"error": "Bewerbung nicht gefunden"}, status_code=404)
     application = _db._serialize_application_row(app_row) if hasattr(_db, '_serialize_application_row') else dict(app_row)
 
     # Enrich with job details if linked
@@ -1305,11 +1314,11 @@ async def api_application_timeline(app_id: str):
         job = _db.get_job(application["job_hash"])
 
     # Get linked documents
-    documents = _db.get_documents_for_application(app_id)
+    documents = _db.get_documents_for_application(app_id, profile_id=profile_id)
 
     # #313: Emails und Meetings als Timeline-Einträge einfügen
-    emails = _db.get_emails_for_application(app_id) if hasattr(_db, 'get_emails_for_application') else []
-    meetings = _db.get_meetings_for_application(app_id) if hasattr(_db, 'get_meetings_for_application') else []
+    emails = _db.get_emails_for_application(app_id, profile_id=profile_id) if hasattr(_db, 'get_emails_for_application') else []
+    meetings = _db.get_meetings_for_application(app_id, profile_id=profile_id) if hasattr(_db, 'get_meetings_for_application') else []
 
     # Unified timeline: events + emails + meetings chronologisch
     unified_timeline = list(events)
@@ -1350,19 +1359,20 @@ async def api_application_timeline(app_id: str):
 @app.get("/api/application/{app_id}/timeline/print")
 async def api_application_timeline_print(app_id: str):
     """Druckbare HTML-Seite des Bewerbungsprotokolls (#313)."""
-    conn = _db.connect()
-    app_row = conn.execute("SELECT * FROM applications WHERE id = ?", (app_id,)).fetchone()
-    if not app_row:
+    profile_id = _get_active_profile_id()
+    app_row = _get_application_row_for_active_profile(app_id)
+    if not profile_id or not app_row:
         return JSONResponse({"error": "Bewerbung nicht gefunden"}, status_code=404)
+    conn = _db.connect()
     app_data = dict(app_row)
 
     events = [dict(r) for r in conn.execute(
         "SELECT * FROM application_events WHERE application_id = ? ORDER BY event_date ASC",
         (app_id,)
     ).fetchall()]
-    emails = _db.get_emails_for_application(app_id) if hasattr(_db, 'get_emails_for_application') else []
-    meetings = _db.get_meetings_for_application(app_id) if hasattr(_db, 'get_meetings_for_application') else []
-    documents = _db.get_documents_for_application(app_id)
+    emails = _db.get_emails_for_application(app_id, profile_id=profile_id) if hasattr(_db, 'get_emails_for_application') else []
+    meetings = _db.get_meetings_for_application(app_id, profile_id=profile_id) if hasattr(_db, 'get_meetings_for_application') else []
+    documents = _db.get_documents_for_application(app_id, profile_id=profile_id)
 
     # Build unified chronological entries
     entries = []
@@ -1546,7 +1556,14 @@ async def api_add_application(request: Request):
 @app.put("/api/applications/{app_id}/status")
 async def api_update_app_status(app_id: str, request: Request):
     data = await request.json()
-    _db.update_application_status(app_id, data["status"], data.get("notes", ""))
+    profile_id = _get_active_profile_id()
+    if not profile_id or not _db.update_application_status(
+        app_id,
+        data["status"],
+        data.get("notes", ""),
+        profile_id=profile_id,
+    ):
+        return JSONResponse({"error": "Bewerbung nicht gefunden"}, status_code=404)
     return {"status": "ok"}
 
 
@@ -1566,8 +1583,14 @@ async def api_update_application(app_id: str, request: Request):
         "description_snapshot", "snapshot_date",
         "applied_at", "is_imported",
     )
+    profile_id = _get_active_profile_id()
+    if not profile_id:
+        return JSONResponse({"error": "Bewerbung nicht gefunden"}, status_code=404)
     conn = _db.connect()
-    app_row = conn.execute("SELECT * FROM applications WHERE id=?", (app_id,)).fetchone()
+    app_row = conn.execute(
+        "SELECT * FROM applications WHERE id=? AND (profile_id=? OR profile_id IS NULL)",
+        (app_id, profile_id),
+    ).fetchone()
     if not app_row:
         return JSONResponse({"error": "Bewerbung nicht gefunden"}, status_code=404)
 
@@ -1603,12 +1626,10 @@ async def api_update_application(app_id: str, request: Request):
     conn.execute(f"UPDATE applications SET {', '.join(sets)} WHERE id=?", vals)
 
     # Log change as timeline event
-    import uuid
-    event_id = str(uuid.uuid4())[:8]
     change_text = "Bewerbung bearbeitet: " + "; ".join(changes)
     conn.execute(
-        "INSERT INTO application_events (id, application_id, status, event_date, notes) VALUES (?, ?, ?, ?, ?)",
-        (event_id, app_id, "bearbeitet", now, change_text)
+        "INSERT INTO application_events (application_id, status, event_date, notes) VALUES (?, ?, ?, ?)",
+        (app_id, "bearbeitet", now, change_text)
     )
     conn.commit()
     return {"status": "ok", "changes": len(changes)}
@@ -1630,6 +1651,8 @@ async def api_link_document(app_id: str, request: Request):
 @app.post("/api/applications/{app_id}/notes")
 async def api_add_note(app_id: str, request: Request):
     """Add a timestamped note to an application."""
+    if not _get_application_row_for_active_profile(app_id):
+        return JSONResponse({"error": "Bewerbung nicht gefunden"}, status_code=404)
     data = await request.json()
     text = (data.get("text") or "").strip()
     if not text:
@@ -1642,6 +1665,8 @@ async def api_add_note(app_id: str, request: Request):
 @app.put("/api/applications/{app_id}/notes/{event_id}")
 async def api_update_note(app_id: str, event_id: int, request: Request):
     """Update an existing note/event text."""
+    if not _get_application_row_for_active_profile(app_id):
+        return JSONResponse({"error": "Bewerbung nicht gefunden"}, status_code=404)
     data = await request.json()
     text = (data.get("text") or "").strip()
     if not text:
@@ -1653,6 +1678,8 @@ async def api_update_note(app_id: str, event_id: int, request: Request):
 @app.delete("/api/applications/{app_id}/notes/{event_id}")
 async def api_delete_note(app_id: str, event_id: int):
     """Delete a note from the application timeline."""
+    if not _get_application_row_for_active_profile(app_id):
+        return JSONResponse({"error": "Bewerbung nicht gefunden"}, status_code=404)
     _db.delete_application_event(event_id, app_id)
     return {"status": "ok"}
 
@@ -1664,6 +1691,8 @@ async def api_snapshot_description(app_id: str, request: Request):
     POST body: { "url": "https://..." }
     Uses simple HTTP fetch + HTML text extraction.
     """
+    if not _get_application_row_for_active_profile(app_id):
+        return JSONResponse({"error": "Bewerbung nicht gefunden"}, status_code=404)
     data = await request.json()
     url = (data.get("url") or "").strip()
     if not url:
@@ -2155,23 +2184,30 @@ async def api_upload_email(file: UploadFile = File(...)):
 @app.post("/api/emails/{email_id}/confirm-match")
 async def api_confirm_email_match(email_id: str, request: Request):
     """Confirm or override auto-matched application for an email."""
+    profile_id = _get_active_profile_id()
     data = await request.json()
     app_id = data.get("application_id")
     if not app_id:
         return JSONResponse({"error": "application_id ist erforderlich"}, status_code=400)
 
-    em = _db.get_email(email_id)
-    if not em:
+    em = _get_email_for_active_profile(email_id)
+    if not profile_id or not em:
         return JSONResponse({"error": "E-Mail nicht gefunden"}, status_code=404)
+    if not _get_application_row_for_active_profile(app_id):
+        return JSONResponse({"error": "Bewerbung nicht gefunden"}, status_code=404)
 
-    _db.update_email(email_id, {"application_id": app_id, "match_confidence": 1.0, "is_processed": 1})
+    _db.update_email(
+        email_id,
+        {"application_id": app_id, "match_confidence": 1.0, "is_processed": 1},
+        profile_id=profile_id,
+    )
 
     # Link any imported documents to the application
     for att in (em.get("attachments_meta") or []):
         doc_id = att.get("doc_id")
         if doc_id:
             try:
-                _db.link_document_to_application(doc_id, app_id)
+                _db.link_document_to_application(doc_id, app_id, profile_id=profile_id)
             except Exception:
                 pass
 
@@ -2203,21 +2239,23 @@ async def api_confirm_email_match(email_id: str, request: Request):
 @app.post("/api/emails/{email_id}/apply-status")
 async def api_apply_email_status(email_id: str, request: Request):
     """Apply the detected status from an email to the linked application."""
+    profile_id = _get_active_profile_id()
     data = await request.json()
     status = data.get("status")
     if not status:
         return JSONResponse({"error": "status ist erforderlich"}, status_code=400)
 
-    em = _db.get_email(email_id)
-    if not em:
+    em = _get_email_for_active_profile(email_id)
+    if not profile_id or not em:
         return JSONResponse({"error": "E-Mail nicht gefunden"}, status_code=404)
     if not em.get("application_id"):
         return JSONResponse({"error": "E-Mail ist keiner Bewerbung zugeordnet"}, status_code=400)
 
     app_id = em["application_id"]
-    _db.update_application_status(app_id, status)
+    if not _db.update_application_status(app_id, status, profile_id=profile_id):
+        return JSONResponse({"error": "Bewerbung nicht gefunden"}, status_code=404)
     _db.add_application_event(app_id, status, f"Status aus E-Mail: {em.get('subject', '')}")
-    _db.update_email(email_id, {"is_processed": 1})
+    _db.update_email(email_id, {"is_processed": 1}, profile_id=profile_id)
 
     # Extract rejection feedback if applicable
     if status == "abgelehnt":
@@ -2239,7 +2277,7 @@ async def api_list_emails():
 @app.get("/api/emails/{email_id}")
 async def api_get_email(email_id: str):
     """Get a single email with full body."""
-    em = _db.get_email(email_id)
+    em = _get_email_for_active_profile(email_id)
     if not em:
         return JSONResponse({"error": "E-Mail nicht gefunden"}, status_code=404)
     return em
@@ -2248,14 +2286,18 @@ async def api_get_email(email_id: str):
 @app.get("/api/applications/{app_id}/emails")
 async def api_get_application_emails(app_id: str):
     """List all emails linked to a specific application."""
-    emails = _db.get_emails_for_application(app_id)
+    profile_id = _get_active_profile_id()
+    if not profile_id or not _get_application_row_for_active_profile(app_id):
+        return JSONResponse({"error": "Bewerbung nicht gefunden"}, status_code=404)
+    emails = _db.get_emails_for_application(app_id, profile_id=profile_id)
     return {"emails": emails, "count": len(emails)}
 
 
 @app.delete("/api/emails/{email_id}")
 async def api_delete_email(email_id: str):
     """Delete an email."""
-    em = _db.get_email(email_id)
+    profile_id = _get_active_profile_id()
+    em = _get_email_for_active_profile(email_id)
     if not em:
         return JSONResponse({"error": "E-Mail nicht gefunden"}, status_code=404)
     # Delete file from disk
@@ -2265,7 +2307,7 @@ async def api_delete_email(email_id: str):
             Path(filepath).unlink(missing_ok=True)
         except Exception:
             pass
-    _db.delete_email(email_id)
+    _db.delete_email(email_id, profile_id=profile_id)
     return {"status": "ok"}
 
 
@@ -2731,8 +2773,10 @@ async def api_update_job(job_hash: str, request: Request):
 @app.post("/api/applications/{app_id}/fit-analyse")
 async def api_save_app_fit_analyse(app_id: str, request: Request):
     """Save fit analysis result to an application (#84)."""
+    profile_id = _get_active_profile_id()
     data = await request.json()
-    _db.save_fit_analyse(app_id, data)
+    if not profile_id or not _db.save_fit_analyse(app_id, data, profile_id=profile_id):
+        return JSONResponse({"error": "Bewerbung nicht gefunden"}, status_code=404)
     return {"status": "ok"}
 
 

--- a/src/bewerbungs_assistent/database.py
+++ b/src/bewerbungs_assistent/database.py
@@ -2131,25 +2131,36 @@ class Database:
         self._auto_link_documents(aid, data.get("company", ""))
         return aid
 
-    def update_application_status(self, app_id: str, new_status: str,
-                                   notes: str = "", rejection_reason: str = ""):
+    def update_application_status(
+        self,
+        app_id: str,
+        new_status: str,
+        notes: str = "",
+        rejection_reason: str = "",
+        profile_id: str = None,
+    ) -> bool:
         conn = self.connect()
         now = _now()
+        params: list[str] = [new_status]
         if rejection_reason and new_status == "abgelehnt":
-            conn.execute(
-                "UPDATE applications SET status=?, rejection_reason=?, updated_at=? WHERE id=?",
-                (new_status, rejection_reason, now, app_id)
-            )
+            query = "UPDATE applications SET status=?, rejection_reason=?, updated_at=? WHERE id=?"
+            params.extend([rejection_reason, now, app_id])
         else:
-            conn.execute(
-                "UPDATE applications SET status=?, updated_at=? WHERE id=?",
-                (new_status, now, app_id)
-            )
+            query = "UPDATE applications SET status=?, updated_at=? WHERE id=?"
+            params.extend([now, app_id])
+        if profile_id is not None:
+            query += " AND (profile_id=? OR profile_id IS NULL)"
+            params.append(profile_id)
+        cur = conn.execute(query, params)
+        if cur.rowcount == 0:
+            conn.commit()
+            return False
         conn.execute("""
             INSERT INTO application_events (application_id, status, event_date, notes)
             VALUES (?, ?, ?, ?)
         """, (app_id, new_status, now, notes))
         conn.commit()
+        return True
 
     def delete_application(self, app_id: str):
         """Delete an application and all its events."""
@@ -2219,10 +2230,15 @@ class Database:
         )
         conn.commit()
 
-    def get_application(self, app_id: str) -> dict | None:
+    def get_application(self, app_id: str, profile_id: str = None) -> dict | None:
         """Get a single application with events."""
         conn = self.connect()
-        row = conn.execute("SELECT * FROM applications WHERE id=?", (app_id,)).fetchone()
+        query = "SELECT * FROM applications WHERE id=?"
+        params: list[str] = [app_id]
+        if profile_id is not None:
+            query += " AND (profile_id=? OR profile_id IS NULL)"
+            params.append(profile_id)
+        row = conn.execute(query, params).fetchone()
         if not row:
             return None
         app = dict(row)
@@ -3020,14 +3036,17 @@ class Database:
             }
         return result
 
-    def save_fit_analyse(self, app_id: str, fit_data: dict):
+    def save_fit_analyse(self, app_id: str, fit_data: dict, profile_id: str = None) -> bool:
         """Save fit analysis result to an application (#84)."""
         conn = self.connect()
-        conn.execute(
-            "UPDATE applications SET fit_analyse=?, updated_at=? WHERE id=?",
-            (json.dumps(fit_data, ensure_ascii=False), _now(), app_id)
-        )
+        query = "UPDATE applications SET fit_analyse=?, updated_at=? WHERE id=?"
+        params: list[str] = [json.dumps(fit_data, ensure_ascii=False), _now(), app_id]
+        if profile_id is not None:
+            query += " AND (profile_id=? OR profile_id IS NULL)"
+            params.append(profile_id)
+        cur = conn.execute(query, params)
         conn.commit()
+        return cur.rowcount > 0
 
     def update_job(self, job_hash: str, data: dict):
         """Update editable fields of a job (#90)."""
@@ -3614,23 +3633,31 @@ class Database:
         conn.commit()
         return eid
 
-    def get_email(self, email_id: str) -> Optional[dict]:
+    def get_email(self, email_id: str, profile_id: str = None) -> Optional[dict]:
         """Get a single email by ID."""
         conn = self.connect()
-        row = conn.execute("SELECT * FROM application_emails WHERE id=?", (email_id,)).fetchone()
+        query = "SELECT * FROM application_emails WHERE id=?"
+        params: list[str] = [email_id]
+        if profile_id is not None:
+            query += " AND (profile_id=? OR profile_id IS NULL)"
+            params.append(profile_id)
+        row = conn.execute(query, params).fetchone()
         if not row:
             return None
         d = dict(row)
         d["attachments_meta"] = json.loads(d.get("attachments_json") or "[]")
         return d
 
-    def get_emails_for_application(self, application_id: str) -> list:
+    def get_emails_for_application(self, application_id: str, profile_id: str = None) -> list:
         """List all emails linked to an application."""
         conn = self.connect()
-        rows = conn.execute(
-            "SELECT * FROM application_emails WHERE application_id=? ORDER BY sent_date DESC",
-            (application_id,),
-        ).fetchall()
+        query = "SELECT * FROM application_emails WHERE application_id=?"
+        params: list[str] = [application_id]
+        if profile_id is not None:
+            query += " AND (profile_id=? OR profile_id IS NULL)"
+            params.append(profile_id)
+        query += " ORDER BY sent_date DESC"
+        rows = conn.execute(query, params).fetchall()
         result = []
         for row in rows:
             d = dict(row)
@@ -3652,7 +3679,7 @@ class Database:
         ).fetchall()
         return [dict(r) for r in rows]
 
-    def update_email(self, email_id: str, data: dict):
+    def update_email(self, email_id: str, data: dict, profile_id: str = None) -> bool:
         """Update email fields (e.g., assign to application)."""
         conn = self.connect()
         allowed = {"application_id", "is_processed", "detected_status",
@@ -3663,19 +3690,28 @@ class Database:
             if k in allowed:
                 sets.append(f"{k}=?")
                 vals.append(v)
-        if sets:
-            vals.append(email_id)
-            conn.execute(
-                f"UPDATE application_emails SET {', '.join(sets)} WHERE id=?",
-                vals,
-            )
-            conn.commit()
+        if not sets:
+            return False
+        query = f"UPDATE application_emails SET {', '.join(sets)} WHERE id=?"
+        vals.append(email_id)
+        if profile_id is not None:
+            query += " AND (profile_id=? OR profile_id IS NULL)"
+            vals.append(profile_id)
+        cur = conn.execute(query, vals)
+        conn.commit()
+        return cur.rowcount > 0
 
-    def delete_email(self, email_id: str):
+    def delete_email(self, email_id: str, profile_id: str = None) -> bool:
         """Delete an email record."""
         conn = self.connect()
-        conn.execute("DELETE FROM application_emails WHERE id=?", (email_id,))
+        query = "DELETE FROM application_emails WHERE id=?"
+        params: list[str] = [email_id]
+        if profile_id is not None:
+            query += " AND (profile_id=? OR profile_id IS NULL)"
+            params.append(profile_id)
+        cur = conn.execute(query, params)
         conn.commit()
+        return cur.rowcount > 0
 
     def get_all_emails(self) -> list:
         """Get all emails for the active profile."""

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -804,6 +804,163 @@ class TestApplicationDetail:
         )
         assert create_same.status_code == 200
 
+    def test_application_and_email_endpoints_reject_cross_profile_access(self, client):
+        """Bewerbungs- und E-Mail-Endpunkte duerfen keine fremden Profile lesen oder veraendern."""
+        import bewerbungs_assistent.dashboard as dash
+
+        pid_a = dash._db.create_profile("Profil A", "a@example.com")
+        app_a = dash._db.add_application({"title": "Job A", "company": "Firma A", "status": "offen"})
+
+        pid_b = dash._db.create_profile("Profil B", "b@example.com")
+        dash._db.switch_profile(pid_b)
+        app_b = dash._db.add_application({"title": "Job B", "company": "Firma B", "status": "offen"})
+        dash._db.add_application_note(app_b, "Geheime Notiz B")
+        conn = dash._db.connect()
+        note_event_id = conn.execute(
+            "SELECT id FROM application_events WHERE application_id=? AND status='notiz' ORDER BY id DESC LIMIT 1",
+            (app_b,),
+        ).fetchone()[0]
+        email_path = Path(os.environ["BA_DATA_DIR"]) / "profil-b-mail.eml"
+        email_path.write_text("Subject: Vertraulich", encoding="utf-8")
+        email_b = dash._db.add_email({
+            "application_id": app_b,
+            "filename": "profil-b-mail.eml",
+            "filepath": str(email_path),
+            "subject": "Interview nur fuer Profil B",
+            "sender": "hr@firma-b.de",
+            "recipients": "b@example.com",
+            "sent_date": "2026-04-10T10:00:00",
+            "body_text": "Vertraulicher Inhalt Profil B",
+        })
+
+        dash._db.switch_profile(pid_a)
+
+        assert client.get(f"/api/application/{app_b}/timeline").status_code == 404
+        assert client.get(f"/api/application/{app_b}/timeline/print").status_code == 404
+        assert client.put(
+            f"/api/applications/{app_b}/status",
+            json={"status": "zusage", "notes": "Profil A aendert Profil B"},
+        ).status_code == 404
+        assert dash._db.get_application(app_b)["status"] == "offen"
+
+        assert client.put(
+            f"/api/applications/{app_b}",
+            json={"company": "Manipulierte Firma"},
+        ).status_code == 404
+        assert dash._db.get_application(app_b)["company"] == "Firma B"
+
+        assert client.post(
+            f"/api/applications/{app_b}/notes",
+            json={"text": "Fremde Notiz"},
+        ).status_code == 404
+        assert client.put(
+            f"/api/applications/{app_b}/notes/{note_event_id}",
+            json={"text": "Ueberschrieben"},
+        ).status_code == 404
+        assert client.delete(f"/api/applications/{app_b}/notes/{note_event_id}").status_code == 404
+        note_row = dash._db.connect().execute(
+            "SELECT notes FROM application_events WHERE id=?",
+            (note_event_id,),
+        ).fetchone()
+        assert note_row["notes"] == "Geheime Notiz B"
+
+        assert client.post(
+            f"/api/applications/{app_b}/snapshot",
+            json={"url": "data:text/html,<html><body>Geheim</body></html>"},
+        ).status_code == 404
+        assert not dash._db.get_application(app_b).get("description_snapshot")
+
+        assert client.post(
+            f"/api/applications/{app_b}/fit-analyse",
+            json={"score": 13, "summary": "Manipuliert"},
+        ).status_code == 404
+        assert dash._db.get_application(app_b).get("fit_analyse") is None
+
+        assert client.get(f"/api/emails/{email_b}").status_code == 404
+        assert client.get(f"/api/applications/{app_b}/emails").status_code == 404
+        assert client.delete(f"/api/emails/{email_b}").status_code == 404
+        assert dash._db.get_email(email_b) is not None
+
+        assert client.post(
+            f"/api/emails/{email_b}/confirm-match",
+            json={"application_id": app_a},
+        ).status_code == 404
+        assert dash._db.get_email(email_b)["application_id"] == app_b
+
+        assert client.post(
+            f"/api/emails/{email_b}/apply-status",
+            json={"status": "abgelehnt"},
+        ).status_code == 404
+        assert dash._db.get_application(app_a)["status"] == "offen"
+        assert dash._db.get_application(app_b)["status"] == "offen"
+
+    def test_application_update_and_email_actions_work_same_profile(self, client):
+        """Same-Profile-Bearbeitung, E-Mail-Linking und Statusuebernahme bleiben funktionsfaehig."""
+        import bewerbungs_assistent.dashboard as dash
+
+        client.post("/api/profile", json={"name": "Tester"})
+        app_id = dash._db.add_application({"title": "Job", "company": "Firma Alt", "status": "offen"})
+        email_path = Path(os.environ["BA_DATA_DIR"]) / "profil-a-mail.eml"
+        email_path.write_text("Subject: Hallo", encoding="utf-8")
+        email_id = dash._db.add_email({
+            "filename": "profil-a-mail.eml",
+            "filepath": str(email_path),
+            "subject": "Intervieweinladung",
+            "sender": "hr@firma.de",
+            "recipients": "tester@example.com",
+            "sent_date": "2026-04-10T10:00:00",
+            "body_text": "Wir laden Sie zum Interview ein.",
+        })
+
+        get_email = client.get(f"/api/emails/{email_id}")
+        assert get_email.status_code == 200
+        assert get_email.json()["subject"] == "Intervieweinladung"
+
+        confirm_match = client.post(
+            f"/api/emails/{email_id}/confirm-match",
+            json={"application_id": app_id},
+        )
+        assert confirm_match.status_code == 200
+        assert dash._db.get_email(email_id)["application_id"] == app_id
+
+        list_emails = client.get(f"/api/applications/{app_id}/emails")
+        assert list_emails.status_code == 200
+        assert list_emails.json()["count"] == 1
+
+        apply_status = client.post(
+            f"/api/emails/{email_id}/apply-status",
+            json={"status": "interview"},
+        )
+        assert apply_status.status_code == 200
+        assert dash._db.get_application(app_id)["status"] == "interview"
+
+        update_application = client.put(
+            f"/api/applications/{app_id}",
+            json={"company": "Firma Neu"},
+        )
+        assert update_application.status_code == 200
+        assert update_application.json()["changes"] == 1
+        assert dash._db.get_application(app_id)["company"] == "Firma Neu"
+
+        save_fit = client.post(
+            f"/api/applications/{app_id}/fit-analyse",
+            json={"score": 42, "summary": "Passt gut"},
+        )
+        assert save_fit.status_code == 200
+        assert dash._db.get_application(app_id)["fit_analyse"]["score"] == 42
+
+        timeline = client.get(f"/api/application/{app_id}/timeline")
+        assert timeline.status_code == 200
+        assert any(event["status"] == "bearbeitet" for event in timeline.json()["events"])
+
+        printable = client.get(f"/api/application/{app_id}/timeline/print")
+        assert printable.status_code == 200
+        assert "Firma Neu" in printable.text
+
+        delete_email = client.delete(f"/api/emails/{email_id}")
+        assert delete_email.status_code == 200
+        assert dash._db.get_email(email_id) is None
+
 
 # ============================================================
 # Gespraechsnotizen


### PR DESCRIPTION
﻿## Zusammenfassung
- schliesst die verbliebenen Cross-Profile-Luecken aus `v1.5.0-beta.19` fuer Bewerbungs- und E-Mail-Endpunkte
- behebt den `datatype mismatch`-500er bei `PUT /api/applications/{app_id}`
- hebt den Release-Stand auf `1.5.0-beta.20` an und zieht Badge/Changelog nach

## Fixes
- Application-/Email-REST-Pfade pruefen jetzt aktives Profil und aktive Bewerbung vor Read/Write
- profilgescopte DB-Zugriffe fuer E-Mails, Fit-Analyse und Status-Updates ergaenzt
- Timeline-Logging bei Bewerbungsbearbeitung schreibt wieder schema-konform ohne String-ID
- Regressionstests fuer Cross-Profile-Angriffe und Same-Profile-Szenarien ergaenzt

## Verifikation
- `python -m pytest tests/ -q` -> `396 passed`
- `python release_check.py` -> alle Checks bestanden
- `pnpm run build` -> erfolgreich

Closes #411
Closes #412
