### PR TITLE
Fix beta.21: CV-Daten Profil-Isolation + Status-Validierung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Alle wichtigen Änderungen am Bewerbungs-Assistent werden hier dokumentiert.
 
+## [1.5.0-beta.21] - 2026-04-10
+
+### Bug Fixes
+- Profil-Isolation fuer CV-Daten-Endpunkte gehaertet: Positionen, Ausbildung, Skills, Jobtitel und Projekte pruefen jetzt das aktive Profil bei PUT und DELETE
+- `PUT /api/applications/{app_id}/status` validiert jetzt das `status`-Feld und liefert 400 statt 500 bei fehlendem Pflichtfeld
+
+### Qualitaet
+- Regressionstests fuer Cross-Profile-Zugriffe auf alle 10 CV-Daten-Endpunkte
+
 ## [1.5.0-beta.20] - 2026-04-10
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Stable](https://img.shields.io/badge/Stable-v1.4.3-brightgreen.svg)](https://github.com/MadGapun/PBP/releases/latest)
 [![Beta](https://img.shields.io/badge/Beta-v1.5.0--beta-orange.svg)](https://github.com/MadGapun/PBP/releases)
-[![Tests](https://img.shields.io/badge/Tests-396-brightgreen.svg)](#tests)
+[![Tests](https://img.shields.io/badge/Tests-398-brightgreen.svg)](#tests)
 [![Tools](https://img.shields.io/badge/MCP_Tools-73-blueviolet.svg)](#mcp-schnittstelle)
 [![Workflows](https://img.shields.io/badge/Workflows-16-ff69b4.svg)](#die-16-workflows)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bewerbungs-assistent"
-version = "1.5.0-beta.20"
+version = "1.5.0-beta.21"
 description = "KI-gestützter Bewerbungsassistent — MCP Server für Claude Desktop"
 readme = {text = "KI-gestützter Bewerbungsassistent als MCP Server für Claude Desktop", content-type = "text/plain"}
 license = "MIT"

--- a/src/bewerbungs_assistent/__init__.py
+++ b/src/bewerbungs_assistent/__init__.py
@@ -1,6 +1,6 @@
 """Bewerbungs-Assistent - KI-gestützter MCP Server für Claude Desktop."""
 
-__version__ = "1.5.0-beta.20"
+__version__ = "1.5.0-beta.21"
 
 
 def main():

--- a/src/bewerbungs_assistent/dashboard.py
+++ b/src/bewerbungs_assistent/dashboard.py
@@ -489,13 +489,17 @@ async def api_add_job_title(request: Request):
 @app.put("/api/job-title/{title_id}")
 async def api_update_job_title(title_id: str, request: Request):
     data = await request.json()
-    _db.update_job_title(title_id, data)
+    profile_id = _get_active_profile_id()
+    if not profile_id or not _db.update_job_title(title_id, data, profile_id=profile_id):
+        return JSONResponse({"error": "Jobtitel nicht gefunden"}, status_code=404)
     return {"status": "ok"}
 
 
 @app.delete("/api/job-title/{title_id}")
 async def api_delete_job_title(title_id: str):
-    _db.delete_job_title(title_id)
+    profile_id = _get_active_profile_id()
+    if not profile_id or not _db.delete_job_title(title_id, profile_id=profile_id):
+        return JSONResponse({"error": "Jobtitel nicht gefunden"}, status_code=404)
     return {"status": "ok"}
 
 
@@ -525,13 +529,17 @@ async def api_update_project(project_id: str, request: Request):
     data = await request.json()
     if not data.get("name", "").strip():
         return JSONResponse({"error": "Projektname ist ein Pflichtfeld"}, status_code=400)
-    _db.update_project(project_id, data)
+    profile_id = _get_active_profile_id()
+    if not profile_id or not _db.update_project(project_id, data, profile_id=profile_id):
+        return JSONResponse({"error": "Projekt nicht gefunden"}, status_code=404)
     return {"status": "ok"}
 
 
 @app.delete("/api/project/{project_id}")
 async def api_delete_project(project_id: str):
-    _db.delete_project(project_id)
+    profile_id = _get_active_profile_id()
+    if not profile_id or not _db.delete_project(project_id, profile_id=profile_id):
+        return JSONResponse({"error": "Projekt nicht gefunden"}, status_code=404)
     return {"status": "ok"}
 
 
@@ -556,39 +564,51 @@ async def api_add_skill(request: Request):
 @app.put("/api/position/{position_id}")
 async def api_update_position(position_id: str, request: Request):
     data = await request.json()
-    _db.update_position(position_id, data)
+    profile_id = _get_active_profile_id()
+    if not profile_id or not _db.update_position(position_id, data, profile_id=profile_id):
+        return JSONResponse({"error": "Position nicht gefunden"}, status_code=404)
     return {"status": "ok"}
 
 
 @app.delete("/api/position/{position_id}")
 async def api_delete_position(position_id: str):
-    _db.delete_position(position_id)
+    profile_id = _get_active_profile_id()
+    if not profile_id or not _db.delete_position(position_id, profile_id=profile_id):
+        return JSONResponse({"error": "Position nicht gefunden"}, status_code=404)
     return {"status": "ok"}
 
 
 @app.put("/api/education/{education_id}")
 async def api_update_education(education_id: str, request: Request):
     data = await request.json()
-    _db.update_education(education_id, data)
+    profile_id = _get_active_profile_id()
+    if not profile_id or not _db.update_education(education_id, data, profile_id=profile_id):
+        return JSONResponse({"error": "Ausbildung nicht gefunden"}, status_code=404)
     return {"status": "ok"}
 
 
 @app.delete("/api/education/{education_id}")
 async def api_delete_education(education_id: str):
-    _db.delete_education(education_id)
+    profile_id = _get_active_profile_id()
+    if not profile_id or not _db.delete_education(education_id, profile_id=profile_id):
+        return JSONResponse({"error": "Ausbildung nicht gefunden"}, status_code=404)
     return {"status": "ok"}
 
 
 @app.put("/api/skill/{skill_id}")
 async def api_update_skill(skill_id: str, request: Request):
     data = await request.json()
-    _db.update_skill(skill_id, data)
+    profile_id = _get_active_profile_id()
+    if not profile_id or not _db.update_skill(skill_id, data, profile_id=profile_id):
+        return JSONResponse({"error": "Skill nicht gefunden"}, status_code=404)
     return {"status": "ok"}
 
 
 @app.delete("/api/skill/{skill_id}")
 async def api_delete_skill(skill_id: str):
-    _db.delete_skill(skill_id)
+    profile_id = _get_active_profile_id()
+    if not profile_id or not _db.delete_skill(skill_id, profile_id=profile_id):
+        return JSONResponse({"error": "Skill nicht gefunden"}, status_code=404)
     return {"status": "ok"}
 
 
@@ -1556,10 +1576,13 @@ async def api_add_application(request: Request):
 @app.put("/api/applications/{app_id}/status")
 async def api_update_app_status(app_id: str, request: Request):
     data = await request.json()
+    new_status = data.get("status")
+    if not new_status:
+        return JSONResponse({"error": "status ist erforderlich"}, status_code=400)
     profile_id = _get_active_profile_id()
     if not profile_id or not _db.update_application_status(
         app_id,
-        data["status"],
+        new_status,
         data.get("notes", ""),
         profile_id=profile_id,
     ):

--- a/src/bewerbungs_assistent/database.py
+++ b/src/bewerbungs_assistent/database.py
@@ -1230,7 +1230,7 @@ class Database:
         conn.commit()
         return pid
 
-    def update_project(self, project_id: str, data: dict):
+    def update_project(self, project_id: str, data: dict, profile_id: str = None) -> bool:
         conn = self.connect()
         fields = ["name", "description", "role", "situation", "task",
                   "action", "result", "technologies", "duration",
@@ -1240,17 +1240,29 @@ class Database:
             if f in data:
                 sets.append(f"{f}=?")
                 vals.append(data[f])
-        if sets:
-            vals.append(project_id)
-            conn.execute(f"UPDATE projects SET {','.join(sets)} WHERE id=?", vals)
-            conn.commit()
-
-    def delete_project(self, project_id: str):
-        conn = self.connect()
-        conn.execute("DELETE FROM projects WHERE id = ?", (project_id,))
+        if not sets:
+            return False
+        query = "UPDATE projects SET {sets} WHERE id=?".format(sets=','.join(sets))
+        vals.append(project_id)
+        if profile_id is not None:
+            query += " AND position_id IN (SELECT id FROM positions WHERE profile_id=? OR profile_id IS NULL)"
+            vals.append(profile_id)
+        cur = conn.execute(query, vals)
         conn.commit()
+        return cur.rowcount > 0
 
-    def update_position(self, position_id: str, data: dict):
+    def delete_project(self, project_id: str, profile_id: str = None) -> bool:
+        conn = self.connect()
+        query = "DELETE FROM projects WHERE id = ?"
+        params: list[str] = [project_id]
+        if profile_id is not None:
+            query += " AND position_id IN (SELECT id FROM positions WHERE profile_id=? OR profile_id IS NULL)"
+            params.append(profile_id)
+        cur = conn.execute(query, params)
+        conn.commit()
+        return cur.rowcount > 0
+
+    def update_position(self, position_id: str, data: dict, profile_id: str = None) -> bool:
         conn = self.connect()
         fields = ["company", "title", "location", "start_date", "end_date",
                   "is_current", "employment_type", "industry", "description",
@@ -1260,12 +1272,18 @@ class Database:
             if f in data:
                 sets.append(f"{f}=?")
                 vals.append(data[f])
-        if sets:
-            vals.append(position_id)
-            conn.execute(f"UPDATE positions SET {','.join(sets)} WHERE id=?", vals)
-            conn.commit()
+        if not sets:
+            return False
+        query = f"UPDATE positions SET {','.join(sets)} WHERE id=?"
+        vals.append(position_id)
+        if profile_id is not None:
+            query += " AND (profile_id=? OR profile_id IS NULL)"
+            vals.append(profile_id)
+        cur = conn.execute(query, vals)
+        conn.commit()
+        return cur.rowcount > 0
 
-    def update_education(self, education_id: str, data: dict):
+    def update_education(self, education_id: str, data: dict, profile_id: str = None) -> bool:
         conn = self.connect()
         fields = ["institution", "degree", "field_of_study", "start_date",
                   "end_date", "grade", "description"]
@@ -1274,12 +1292,18 @@ class Database:
             if f in data:
                 sets.append(f"{f}=?")
                 vals.append(data[f])
-        if sets:
-            vals.append(education_id)
-            conn.execute(f"UPDATE education SET {','.join(sets)} WHERE id=?", vals)
-            conn.commit()
+        if not sets:
+            return False
+        query = f"UPDATE education SET {','.join(sets)} WHERE id=?"
+        vals.append(education_id)
+        if profile_id is not None:
+            query += " AND (profile_id=? OR profile_id IS NULL)"
+            vals.append(profile_id)
+        cur = conn.execute(query, vals)
+        conn.commit()
+        return cur.rowcount > 0
 
-    def update_skill(self, skill_id: str, data: dict):
+    def update_skill(self, skill_id: str, data: dict, profile_id: str = None) -> bool:
         conn = self.connect()
         fields = ["name", "category", "level", "years_experience", "last_used_year"]
         sets, vals = [], []
@@ -1287,16 +1311,28 @@ class Database:
             if f in data:
                 sets.append(f"{f}=?")
                 vals.append(data[f])
-        if sets:
-            vals.append(skill_id)
-            conn.execute(f"UPDATE skills SET {','.join(sets)} WHERE id=?", vals)
-            conn.commit()
+        if not sets:
+            return False
+        query = f"UPDATE skills SET {','.join(sets)} WHERE id=?"
+        vals.append(skill_id)
+        if profile_id is not None:
+            query += " AND (profile_id=? OR profile_id IS NULL)"
+            vals.append(profile_id)
+        cur = conn.execute(query, vals)
+        conn.commit()
+        return cur.rowcount > 0
 
-    def delete_position(self, position_id: str):
+    def delete_position(self, position_id: str, profile_id: str = None) -> bool:
         conn = self.connect()
         # Projects are deleted automatically via ON DELETE CASCADE
-        conn.execute("DELETE FROM positions WHERE id = ?", (position_id,))
+        query = "DELETE FROM positions WHERE id = ?"
+        params: list[str] = [position_id]
+        if profile_id is not None:
+            query += " AND (profile_id=? OR profile_id IS NULL)"
+            params.append(profile_id)
+        cur = conn.execute(query, params)
         conn.commit()
+        return cur.rowcount > 0
 
     # === Education ===
 
@@ -1328,10 +1364,16 @@ class Database:
         conn.commit()
         return eid
 
-    def delete_education(self, education_id: str):
+    def delete_education(self, education_id: str, profile_id: str = None) -> bool:
         conn = self.connect()
-        conn.execute("DELETE FROM education WHERE id = ?", (education_id,))
+        query = "DELETE FROM education WHERE id = ?"
+        params: list[str] = [education_id]
+        if profile_id is not None:
+            query += " AND (profile_id=? OR profile_id IS NULL)"
+            params.append(profile_id)
+        cur = conn.execute(query, params)
         conn.commit()
+        return cur.rowcount > 0
 
     # === Skills ===
 
@@ -1443,10 +1485,16 @@ class Database:
         conn.commit()
         return sid
 
-    def delete_skill(self, skill_id: str):
+    def delete_skill(self, skill_id: str, profile_id: str = None) -> bool:
         conn = self.connect()
-        conn.execute("DELETE FROM skills WHERE id = ?", (skill_id,))
+        query = "DELETE FROM skills WHERE id = ?"
+        params: list[str] = [skill_id]
+        if profile_id is not None:
+            query += " AND (profile_id=? OR profile_id IS NULL)"
+            params.append(profile_id)
+        cur = conn.execute(query, params)
         conn.commit()
+        return cur.rowcount > 0
 
     # === Suggested Job Titles ===
 
@@ -1472,7 +1520,7 @@ class Database:
         conn.commit()
         return tid
 
-    def update_job_title(self, title_id: str, data: dict):
+    def update_job_title(self, title_id: str, data: dict, profile_id: str = None) -> bool:
         conn = self.connect()
         fields = ["title", "is_active", "confidence"]
         sets, vals = [], []
@@ -1480,15 +1528,27 @@ class Database:
             if f in data:
                 sets.append(f"{f}=?")
                 vals.append(data[f])
-        if sets:
-            vals.append(title_id)
-            conn.execute(f"UPDATE suggested_job_titles SET {','.join(sets)} WHERE id=?", vals)
-            conn.commit()
-
-    def delete_job_title(self, title_id: str):
-        conn = self.connect()
-        conn.execute("DELETE FROM suggested_job_titles WHERE id=?", (title_id,))
+        if not sets:
+            return False
+        query = f"UPDATE suggested_job_titles SET {','.join(sets)} WHERE id=?"
+        vals.append(title_id)
+        if profile_id is not None:
+            query += " AND (profile_id=? OR profile_id IS NULL)"
+            vals.append(profile_id)
+        cur = conn.execute(query, vals)
         conn.commit()
+        return cur.rowcount > 0
+
+    def delete_job_title(self, title_id: str, profile_id: str = None) -> bool:
+        conn = self.connect()
+        query = "DELETE FROM suggested_job_titles WHERE id=?"
+        params: list[str] = [title_id]
+        if profile_id is not None:
+            query += " AND (profile_id=? OR profile_id IS NULL)"
+            params.append(profile_id)
+        cur = conn.execute(query, params)
+        conn.commit()
+        return cur.rowcount > 0
 
     # === Documents ===
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -961,6 +961,83 @@ class TestApplicationDetail:
         assert delete_email.status_code == 200
         assert dash._db.get_email(email_id) is None
 
+    def test_cv_data_endpoints_reject_cross_profile_access(self, client):
+        """Positions, Education, Skills, Job-Titles und Projects duerfen keine fremden Profile aendern."""
+        import bewerbungs_assistent.dashboard as dash
+
+        pid_a = dash._db.create_profile("Profil A", "a@example.com")
+        conn = dash._db.connect()
+
+        pid_b = dash._db.create_profile("Profil B", "b@example.com")
+        dash._db.switch_profile(pid_b)
+        conn.execute(
+            "INSERT INTO positions (id, profile_id, company, title, start_date) VALUES (?,?,?,?,?)",
+            ("pos_b", pid_b, "Firma B", "Dev B", "2021-01-01"),
+        )
+        conn.execute(
+            "INSERT INTO education (id, profile_id, institution, degree, field_of_study, start_date) VALUES (?,?,?,?,?,?)",
+            ("edu_b", pid_b, "Uni B", "BSc", "Mathe", "2016-01-01"),
+        )
+        conn.execute(
+            "INSERT INTO skills (id, profile_id, name, level) VALUES (?,?,?,?)",
+            ("skill_b", pid_b, "Java", "advanced"),
+        )
+        conn.execute(
+            "INSERT INTO suggested_job_titles (id, profile_id, title, source, confidence) VALUES (?,?,?,?,?)",
+            ("jt_b", pid_b, "Manager", "manual", 1.0),
+        )
+        conn.execute(
+            "INSERT INTO projects (id, position_id, name, description) VALUES (?,?,?,?)",
+            ("proj_b", "pos_b", "Geheimprojekt", "Vertraulich"),
+        )
+        conn.commit()
+
+        dash._db.switch_profile(pid_a)
+
+        # Position: PUT und DELETE
+        assert client.put("/api/position/pos_b", json={"title": "HACKED"}).status_code == 404
+        assert conn.execute("SELECT title FROM positions WHERE id='pos_b'").fetchone()[0] == "Dev B"
+        assert client.delete("/api/position/pos_b").status_code == 404
+        assert conn.execute("SELECT id FROM positions WHERE id='pos_b'").fetchone() is not None
+
+        # Education: PUT und DELETE
+        assert client.put("/api/education/edu_b", json={"institution": "HACKED"}).status_code == 404
+        assert conn.execute("SELECT institution FROM education WHERE id='edu_b'").fetchone()[0] == "Uni B"
+        assert client.delete("/api/education/edu_b").status_code == 404
+        assert conn.execute("SELECT id FROM education WHERE id='edu_b'").fetchone() is not None
+
+        # Skill: PUT und DELETE
+        assert client.put("/api/skill/skill_b", json={"name": "HACKED"}).status_code == 404
+        assert conn.execute("SELECT name FROM skills WHERE id='skill_b'").fetchone()[0] == "Java"
+        assert client.delete("/api/skill/skill_b").status_code == 404
+        assert conn.execute("SELECT id FROM skills WHERE id='skill_b'").fetchone() is not None
+
+        # Job-Title: PUT und DELETE
+        assert client.put("/api/job-title/jt_b", json={"title": "HACKED"}).status_code == 404
+        assert conn.execute("SELECT title FROM suggested_job_titles WHERE id='jt_b'").fetchone()[0] == "Manager"
+        assert client.delete("/api/job-title/jt_b").status_code == 404
+        assert conn.execute("SELECT id FROM suggested_job_titles WHERE id='jt_b'").fetchone() is not None
+
+        # Project: PUT und DELETE
+        assert client.put("/api/project/proj_b", json={"name": "HACKED"}).status_code == 404
+        assert conn.execute("SELECT name FROM projects WHERE id='proj_b'").fetchone()[0] == "Geheimprojekt"
+        assert client.delete("/api/project/proj_b").status_code == 404
+        assert conn.execute("SELECT id FROM projects WHERE id='proj_b'").fetchone() is not None
+
+    def test_status_update_requires_status_field(self, client):
+        """PUT /api/applications/{app_id}/status muss 400 liefern wenn status fehlt."""
+        import bewerbungs_assistent.dashboard as dash
+
+        dash._db.create_profile("Tester", "t@example.com")
+        app_id = dash._db.add_application({"title": "Job", "company": "Firma", "status": "offen"})
+
+        r = client.put(f"/api/applications/{app_id}/status", json={})
+        assert r.status_code == 400
+        assert "status" in r.json()["error"].lower()
+
+        r = client.put(f"/api/applications/{app_id}/status", json={"notes": "nur notiz"})
+        assert r.status_code == 400
+
 
 # ============================================================
 # Gespraechsnotizen


### PR DESCRIPTION
## Zusammenfassung
- Schliesst die verbliebenen Cross-Profile-Luecken fuer CV-Daten-Endpunkte (Positions, Education, Skills, Job-Titles, Projects)
- Behebt den `KeyError`-500er bei `PUT /api/applications/{app_id}/status` ohne `status`-Feld
- Hebt den Release-Stand auf `1.5.0-beta.21` an

## QA-Befunde
Vollstaendige QA-Durchsicht v1.4.3 → v1.5.0-beta.20 hat zwei weitere Release-Blocker ergeben:
- **#414**: 10 CV-Daten-Endpunkte (PUT/DELETE fuer Positionen, Ausbildung, Skills, Jobtitel, Projekte) erlauben profilfremde Aenderungen
- **#415**: `PUT /api/applications/{app_id}/status` crasht mit 500/KeyError wenn `status`-Feld fehlt

## Fixes
- Alle 10 Dashboard-Endpunkte pruefen jetzt `_get_active_profile_id()` und geben 404 bei fremdem Profil
- Alle 10 DB-Methoden akzeptieren `profile_id`-Parameter und filtern in der WHERE-Klausel
- Status-Endpoint validiert Pflichtfeld `status` und gibt 400 statt 500

## Verifikation
- `python -m pytest tests/ -q` → 373 passed, 15 skipped (10 fpdf vorbestehend)
- `python release_check.py` → alle Checks bestanden
- `pnpm run build` → erfolgreich
- Cross-Profile-Simulation: alle 10 Angriffe → 404, Same-Profile → 200

Closes #414
Closes #415