### PR TITLE
v1.5.4: MCP Write-Back-Luecken schliessen (#443-#448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,70 @@
 
 Alle wichtigen Änderungen am Bewerbungs-Assistent werden hier dokumentiert.
 
+## [1.5.4] - 2026-04-15
+
+Schliesst die letzten Write-Back-Luecken im MCP-Server. Claude kann jetzt alles,
+was im Dashboard sichtbar ist, auch selbst pflegen — ohne Umweg ueber direktes SQL.
+
+### Warum dieses Release
+
+Ein Anwender hatte berichtet, dass "nicht alles von Claude zurueckgeschrieben wird".
+Pruefung hat bestaetigt: fuer Meetings, Emails, Stellen-Korrekturen und mehrere
+Dokument-Operationen gab es zwar die DB-Schicht, aber keine passenden MCP-Tools.
+Folge: Claude musste in manchen Situationen auf Desktop-Commander + direktes SQL
+ausweichen, was fehleranfaellig und fuer den Anwender nicht nachvollziehbar war.
+v1.5.4 schliesst diese Luecken. Die oeffentliche MCP-Schnittstelle waechst von
+73 auf **84 Tools**.
+
+### Neue MCP-Tools (11)
+
+**Meetings** (#444) — bisher nur lesbar ueber `bewerbung_details`, jetzt voll pflegbar:
+- `meeting_hinzufuegen` — Interview, Telefonat, Kennenlerngespraech etc. anlegen
+- `meeting_bearbeiten` — Datum, Typ, Ort, Plattform, Notizen, Status aendern
+- `meeting_loeschen` — mit Zwei-Phasen-Bestaetigung
+- `meetings_anzeigen` — gefiltert nach Bewerbung oder als Terminvorschau fuer die naechsten N Tage
+
+**Emails** (#445) — Posteingang war nur einlesbar, jetzt komplett zuordenbar:
+- `email_verknuepfen` — Email einer Bewerbung zuordnen (oder Verknuepfung loesen)
+- `email_loeschen` — mit Zwei-Phasen-Bestaetigung
+- `emails_anzeigen` — pro Bewerbung oder Liste aller nicht zugeordneten Emails
+
+**Stellen** (#446):
+- `stelle_bearbeiten` — Titel, Firma, Ort, Beschreibung korrigieren wenn der Scraper
+  etwas falsch uebernommen hat. Kein Umweg mehr ueber `stelle_manuell_anlegen` +
+  Loeschen der alten Stelle.
+
+**Dokumente** (#447):
+- `dokument_entverknuepfen` — Dokument von einer Bewerbung loesen (Gegenstueck zu `dokument_verknuepfen`)
+- `dokument_loeschen` — mit Zwei-Phasen-Bestaetigung, loescht auch die Datei auf Disk
+- `dokument_status_setzen` — Extraktions-Status manuell setzen (`nicht_extrahiert`,
+  `gestartet`, `extrahiert`, `angewendet`)
+
+### Erweiterte Tools
+
+- **`bewerbung_bearbeiten`** (#448): akzeptiert jetzt auch `cover_letter_path` und
+  `cv_path`. Damit lassen sich die in der Bewerbung hinterlegten Dokumentpfade
+  aendern, ohne erneut zu exportieren.
+
+### Prompts
+
+- `bewerbung_vorbereitung` und `interview_vorbereitung` erwaehnen die neuen
+  Meeting-Tools und `dokument_entverknuepfen`, damit Claude sie in den
+  richtigen Situationen anbietet.
+
+### Unter der Haube
+
+- 19 neue Regressionstests fuer alle neuen Tools (`tests/test_v154_writeback.py`)
+- `test_mcp_registry` prueft jetzt **84 Tools** (vorher 73)
+- `db.update_application` akzeptiert `cover_letter_path` und `cv_path` in der
+  Whitelist (#448)
+- Keine Schema-Aenderung, keine Migration — v1.5.3-Datenbanken laufen ohne Anpassung weiter
+
+### Upgrade
+
+Einfach die [neue Version herunterladen](https://github.com/MadGapun/PBP/releases/latest)
+und installieren. Bestehende Daten bleiben unveraendert.
+
 ## [1.5.3] - 2026-04-15
 
 Stabilisierungs-Release direkt nach dem Launch von v1.5. Keine neuen Features —

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![MCP](https://img.shields.io/badge/MCP-Claude_Desktop-orange.svg)](https://modelcontextprotocol.io/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Stable](https://img.shields.io/badge/Stable-v1.5.0-brightgreen.svg)](https://github.com/MadGapun/PBP/releases/latest)
-[![Tests](https://img.shields.io/badge/Tests-401-brightgreen.svg)](#tests)
+[![Tests](https://img.shields.io/badge/Tests-429-brightgreen.svg)](#tests)
 [![Tools](https://img.shields.io/badge/MCP_Tools-73-blueviolet.svg)](https://github.com/MadGapun/PBP/wiki/MCP-Tools)
 [![Workflows](https://img.shields.io/badge/Workflows-18-ff69b4.svg)](https://github.com/MadGapun/PBP/wiki/Workflows)
 [![Plattformen](https://img.shields.io/badge/Plattformen-Windows_%7C_macOS_%7C_Linux-blue.svg)](#schnellstart)
@@ -195,12 +195,12 @@ Claude führt dich durch ein lockeres Gespräch (ca. 10-15 Minuten) und baut dei
 | | |
 |---|---|
 | **Plattformen** | Windows, macOS, Linux |
-| **MCP-Tools** | 73 Tools in 8 Modulen |
+| **MCP-Tools** | 84 Tools in 8 Modulen |
 | **Workflows** | 18 gefuehrte Workflows |
 | **Jobportale** | 18 Quellen (11 schnell, 4 Browser, 3 manuell) |
 | **Dashboard** | 8 Tabs: Dashboard, Profil, Stellen, Bewerbungen, Dokumente, Kalender, Statistiken, Einstellungen |
 | **Datenbank** | SQLite, 29 Tabellen, Schema v23 |
-| **Tests** | 401 bestanden |
+| **Tests** | 429 bestanden |
 
 > 📖 **Technische Details:** [Wiki → Architektur](https://github.com/MadGapun/PBP/wiki/Architektur) · [MCP-Tools](https://github.com/MadGapun/PBP/wiki/MCP-Tools) · [Jobportale](https://github.com/MadGapun/PBP/wiki/Jobportale)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bewerbungs-assistent"
-version = "1.5.3"
+version = "1.5.4"
 description = "KI-gestützter Bewerbungsassistent — MCP Server für Claude Desktop"
 readme = {text = "KI-gestützter Bewerbungsassistent als MCP Server für Claude Desktop", content-type = "text/plain"}
 license = "MIT"
@@ -54,3 +54,8 @@ bewerbungs-assistent = "bewerbungs_assistent:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/bewerbungs_assistent"]
+
+[tool.pytest.ini_options]
+# test_demo.py im Projekt-Root ist ein Dashboard-Launcher-Script, kein Pytest-Test.
+# Ohne testpaths wuerde pytest es einsammeln und beim Start des Uvicorn-Servers haengen.
+testpaths = ["tests"]

--- a/src/bewerbungs_assistent/__init__.py
+++ b/src/bewerbungs_assistent/__init__.py
@@ -1,6 +1,6 @@
 """Bewerbungs-Assistent - KI-gestützter MCP Server für Claude Desktop."""
 
-__version__ = "1.5.3"
+__version__ = "1.5.4"
 
 
 def main():

--- a/src/bewerbungs_assistent/database.py
+++ b/src/bewerbungs_assistent/database.py
@@ -2297,7 +2297,7 @@ class Database:
         conn.commit()
 
     def update_application(self, app_id: str, data: dict):
-        """Update application fields (#181: erweitert um employment_type, source, vermittler, endkunde)."""
+        """Update application fields (#181: employment_type/source/vermittler/endkunde, #448: cover_letter_path/cv_path)."""
         conn = self.connect()
         now = _now()
         fields = []
@@ -2305,7 +2305,8 @@ class Database:
         allowed_keys = ("title", "company", "url", "notes", "ansprechpartner",
                         "kontakt_email", "portal_name", "bewerbungsart",
                         "employment_type", "source", "source_secondary",
-                        "vermittler", "endkunde", "applied_at")
+                        "vermittler", "endkunde", "applied_at",
+                        "cover_letter_path", "cv_path")
         for key in allowed_keys:
             if key in data:
                 fields.append(f"{key}=?")

--- a/src/bewerbungs_assistent/prompts.py
+++ b/src/bewerbungs_assistent/prompts.py
@@ -735,6 +735,7 @@ REGELN:
 - Alles MUSS personalisiert sein — nutze konkrete Projekte, Erfolge, Zahlen aus dem Profil
 - Sei ermutigend: "Du hast X Jahre Erfahrung in Y — das ist eine echte Stärke!"
 - Biete an: "Soll ich mit dir ein Probe-Interview ueben?"
+- Wenn der User den Gespraechstermin nennt: sofort mit meeting_hinzufuegen(bewerbung_id, datum, typ='interview', ...) speichern
 - Am Ende: "Soll ich den Status deiner Bewerbung bei {firma} auf 'interview' setzen?"
   → bewerbung_status_ändern(id, 'interview', notizen)"""
 
@@ -1480,6 +1481,10 @@ WICHTIGE REGELN
 - Nach JEDEM Schritt: Timeline-Eintrag erstellen mit bewerbung_notiz()
   z.B. "Fit-Analyse durchgefuehrt (Score: 78)" oder "CV angepasst und exportiert"
 - Automatisch dokument_verknuepfen() aufrufen wenn Dokumente erstellt werden
+- Wenn der User einen Gespraechstermin erwaehnt: SOFORT mit meeting_hinzufuegen() speichern
+  (typ='interview'|'telefon'|'video', datum als ISO-String)
+- Falsch zugeordnete Dokumente mit dokument_entverknuepfen() loesen, dann korrekt verknuepfen
+- Anschreiben-/CV-Pfade nach Export ueber bewerbung_bearbeiten(cover_letter_path=..., cv_path=...) ablegen
 - Den User NICHT mit allen Schritten auf einmal überfordern — immer nur den nächsten zeigen
 - Bei Unsicherheit: Aufmuntern! "Das sieht gut aus. Lass uns weitermachen."
 - Wenn der User frustriert wirkt: "Jeder Schritt zaehlt. Du machst das richtig."

--- a/src/bewerbungs_assistent/tools/bewerbungen.py
+++ b/src/bewerbungs_assistent/tools/bewerbungen.py
@@ -1,4 +1,4 @@
-"""Bewerbungs-Management — 9 Tools (#170: geführter Workflow)."""
+"""Bewerbungs-Management — 16 Tools (#170: geführter Workflow, #443: Write-Back-Gaps)."""
 
 import hashlib
 
@@ -480,6 +480,8 @@ def register(mcp, db, logger):
         source: str = "",
         vermittler: str = "",
         endkunde: str = "",
+        cover_letter_path: str = "",
+        cv_path: str = "",
     ) -> dict:
         """Bearbeitet eine bestehende Bewerbung (Felder nachträglich ändern/ergänzen).
 
@@ -499,6 +501,8 @@ def register(mcp, db, logger):
             source: Quelle der Stelle (stepstone, indeed, linkedin, manuell, etc.)
             vermittler: Name des Vermittlers/der Agentur
             endkunde: Name des Endkunden (bei Freelance/Vermittlung)
+            cover_letter_path: Pfad zum Anschreiben-PDF (#448)
+            cv_path: Pfad zum Lebenslauf-PDF (#448)
         """
         app = db.get_application(bewerbung_id)
         if not app:
@@ -509,7 +513,8 @@ def register(mcp, db, logger):
                          ("notes", notes), ("ansprechpartner", ansprechpartner),
                          ("kontakt_email", kontakt_email), ("portal_name", portal_name),
                          ("bewerbungsart", bewerbungsart), ("employment_type", employment_type),
-                         ("source", source), ("vermittler", vermittler), ("endkunde", endkunde)]:
+                         ("source", source), ("vermittler", vermittler), ("endkunde", endkunde),
+                         ("cover_letter_path", cover_letter_path), ("cv_path", cv_path)]:
             if val:
                 updates[key] = val
 
@@ -665,3 +670,293 @@ def register(mcp, db, logger):
         stats["pipeline"] = pipeline
 
         return stats
+
+    # === Meetings (#444) ===================================================
+    # Schreibzugriff auf application_meetings. Bisher konnte Claude Interviews,
+    # Telefonate und Termine nur per direktem SQL anlegen — jetzt sauber ueber MCP.
+
+    _MEETING_TYPES = {
+        "interview", "telefon", "video", "vor_ort", "kennenlernen",
+        "zweitgespraech", "assessment", "probearbeiten", "vertrag", "sonstiges",
+    }
+    _MEETING_STATUS = {"geplant", "bestaetigt", "abgeschlossen", "abgesagt", "verschoben"}
+
+    @mcp.tool()
+    def meeting_hinzufuegen(
+        bewerbung_id: str,
+        datum: str,
+        typ: str = "interview",
+        platform: str = "",
+        ort: str = "",
+        titel: str = "",
+        notizen: str = "",
+        dauer_minuten: int = 0,
+        status: str = "geplant",
+    ) -> dict:
+        """Fuegt einen Termin (Interview, Telefonat, Video-Call) zu einer Bewerbung hinzu (#444).
+
+        Nutze dies immer wenn der Anwender einen Gespraechstermin erwaehnt. Das
+        Meeting erscheint anschliessend in `bewerbung_details()` und im Kalender.
+
+        Args:
+            bewerbung_id: ID der Bewerbung (aus bewerbungen_anzeigen)
+            datum: Datum/Uhrzeit als ISO-String (z.B. '2026-04-18T14:00' oder '2026-04-18 14:00')
+            typ: Meeting-Typ (interview, telefon, video, vor_ort, kennenlernen, zweitgespraech, assessment, probearbeiten, vertrag, sonstiges)
+            platform: Plattform bei Video-Calls (z.B. 'Teams', 'Zoom', 'Google Meet')
+            ort: Ort bei Vor-Ort-Terminen
+            titel: Optionaler Titel (Default: abgeleitet vom Typ)
+            notizen: Freie Notizen zum Termin
+            dauer_minuten: Geplante Dauer in Minuten (0 = unbekannt)
+            status: Status (geplant, bestaetigt, abgeschlossen, abgesagt, verschoben)
+        """
+        app = db.get_application(bewerbung_id)
+        if not app:
+            return {"fehler": "Bewerbung nicht gefunden. Prüfe die ID mit bewerbungen_anzeigen()."}
+        if not datum:
+            return {"fehler": "Datum ist ein Pflichtfeld."}
+        if typ not in _MEETING_TYPES:
+            return {
+                "fehler": f"Ungueltiger Typ '{typ}'.",
+                "erlaubte_typen": sorted(_MEETING_TYPES),
+            }
+        if status not in _MEETING_STATUS:
+            return {
+                "fehler": f"Ungueltiger Status '{status}'.",
+                "erlaubte_status": sorted(_MEETING_STATUS),
+            }
+
+        data = {
+            "application_id": bewerbung_id,
+            "title": titel or f"{typ.capitalize()} — {app.get('company', '')}".strip(" —"),
+            "meeting_date": datum,
+            "meeting_type": typ,
+            "platform": platform or None,
+            "location": ort,
+            "notes": notizen or None,
+            "status": status,
+            "duration_minutes": dauer_minuten or None,
+        }
+        meeting_id = db.add_meeting(data)
+        return {
+            "status": "angelegt",
+            "meeting_id": meeting_id,
+            "bewerbung": f"{app.get('title', '')} bei {app.get('company', '')}",
+            "typ": typ,
+            "datum": datum,
+            "nachricht": (
+                f"{typ.capitalize()} am {datum} zu '{app.get('title', '')}' "
+                f"bei {app.get('company', '')} gespeichert."
+            ),
+        }
+
+    @mcp.tool()
+    def meeting_bearbeiten(
+        meeting_id: str,
+        titel: str = "",
+        datum: str = "",
+        ort: str = "",
+        platform: str = "",
+        notizen: str = "",
+        status: str = "",
+        dauer_minuten: int = 0,
+    ) -> dict:
+        """Aktualisiert einen bestehenden Termin (#444).
+
+        Nur die angegebenen Felder werden geaendert. Leere Strings bleiben unveraendert.
+        Nutze dies z.B. um einen Termin zu bestaetigen, zu verschieben oder Notizen zu ergaenzen.
+
+        Args:
+            meeting_id: ID des Meetings (aus meetings_anzeigen)
+            titel: Neuer Titel
+            datum: Neues Datum/Uhrzeit (ISO-String)
+            ort: Neuer Ort
+            platform: Neue Plattform
+            notizen: Neue Notizen (ueberschreibt bisherige)
+            status: Neuer Status (geplant, bestaetigt, abgeschlossen, abgesagt, verschoben)
+            dauer_minuten: Neue Dauer (0 = nicht aendern)
+        """
+        updates: dict = {}
+        if titel:
+            updates["title"] = titel
+        if datum:
+            updates["meeting_date"] = datum
+        if ort:
+            updates["location"] = ort
+        if platform:
+            updates["platform"] = platform
+        if notizen:
+            updates["notes"] = notizen
+        if status:
+            if status not in _MEETING_STATUS:
+                return {
+                    "fehler": f"Ungueltiger Status '{status}'.",
+                    "erlaubte_status": sorted(_MEETING_STATUS),
+                }
+            updates["status"] = status
+        if dauer_minuten:
+            updates["duration_minutes"] = dauer_minuten
+
+        if not updates:
+            return {"fehler": "Keine Aenderungen angegeben."}
+
+        profile_id = db.get_active_profile_id()
+        changed = db.update_meeting(meeting_id, updates, profile_id=profile_id)
+        if not changed:
+            return {"fehler": "Meeting nicht gefunden oder gehoert nicht zum aktiven Profil."}
+        return {
+            "status": "aktualisiert",
+            "meeting_id": meeting_id,
+            "geaenderte_felder": list(updates.keys()),
+        }
+
+    @mcp.tool()
+    def meeting_loeschen(meeting_id: str, bestaetigung: bool = False) -> dict:
+        """Loescht einen Termin (#444).
+
+        ACHTUNG: Nicht rueckgaengig zu machen. Beim ersten Aufruf ohne
+        Bestaetigung wird nur eine Rueckfrage zurueckgegeben.
+
+        Args:
+            meeting_id: ID des Meetings
+            bestaetigung: Muss True sein um tatsaechlich zu loeschen
+        """
+        profile_id = db.get_active_profile_id()
+        if not bestaetigung:
+            return {
+                "status": "bestaetigung_erforderlich",
+                "meeting_id": meeting_id,
+                "hinweis": "Setze bestaetigung=True um den Termin unwiderruflich zu loeschen.",
+            }
+        deleted = db.delete_meeting(meeting_id, profile_id=profile_id)
+        if not deleted:
+            return {"fehler": "Meeting nicht gefunden oder gehoert nicht zum aktiven Profil."}
+        return {"status": "geloescht", "meeting_id": meeting_id}
+
+    @mcp.tool()
+    def meetings_anzeigen(bewerbung_id: str = "", tage: int = 30) -> dict:
+        """Zeigt Termine — entweder fuer eine bestimmte Bewerbung oder kommende im Zeitraum (#444).
+
+        Args:
+            bewerbung_id: Optional — wenn gesetzt, nur Termine zu dieser Bewerbung
+            tage: Wenn keine Bewerbung angegeben: Anzahl Tage in die Zukunft (Default: 30)
+        """
+        profile_id = db.get_active_profile_id()
+        if bewerbung_id:
+            app = db.get_application(bewerbung_id)
+            if not app:
+                return {"fehler": "Bewerbung nicht gefunden."}
+            meetings = db.get_meetings_for_application(bewerbung_id, profile_id=profile_id)
+            return {
+                "status": "ok",
+                "bewerbung": f"{app.get('title', '')} bei {app.get('company', '')}",
+                "anzahl": len(meetings),
+                "meetings": meetings,
+            }
+        meetings = db.get_upcoming_meetings(days=tage)
+        return {
+            "status": "ok",
+            "zeitraum_tage": tage,
+            "anzahl": len(meetings),
+            "meetings": meetings,
+        }
+
+    # === E-Mails (#445) ====================================================
+    # Schreibzugriff auf application_emails. Tools um E-Mails manuell mit
+    # Bewerbungen zu verknuepfen, zu loeschen oder unmatched aufzulisten.
+
+    @mcp.tool()
+    def email_verknuepfen(email_id: str, bewerbung_id: str) -> dict:
+        """Verknuepft eine eingegangene E-Mail mit einer Bewerbung (#445).
+
+        Nutze dies fuer E-Mails die die Pipeline nicht automatisch zuordnen
+        konnte oder die falsch zugeordnet wurden. Setze `bewerbung_id` auf den
+        leeren String um die Verknuepfung zu entfernen (E-Mail wird wieder
+        'unmatched').
+
+        Args:
+            email_id: ID der E-Mail (aus emails_anzeigen)
+            bewerbung_id: ID der Bewerbung ODER leerer String zum Entkoppeln
+        """
+        profile_id = db.get_active_profile_id()
+        email = db.get_email(email_id, profile_id=profile_id)
+        if not email:
+            return {"fehler": "E-Mail nicht gefunden."}
+
+        if bewerbung_id:
+            app = db.get_application(bewerbung_id)
+            if not app:
+                return {"fehler": "Bewerbung nicht gefunden."}
+            changed = db.update_email(
+                email_id, {"application_id": bewerbung_id}, profile_id=profile_id
+            )
+            if not changed:
+                return {"fehler": "Verknuepfung konnte nicht aktualisiert werden."}
+            return {
+                "status": "verknuepft",
+                "email_id": email_id,
+                "bewerbung": f"{app.get('title', '')} bei {app.get('company', '')}",
+                "betreff": email.get("subject", ""),
+            }
+        # bewerbung_id leer -> entkoppeln
+        changed = db.update_email(
+            email_id, {"application_id": None}, profile_id=profile_id
+        )
+        if not changed:
+            return {"fehler": "Entkoppelung konnte nicht aktualisiert werden."}
+        return {
+            "status": "entkoppelt",
+            "email_id": email_id,
+            "betreff": email.get("subject", ""),
+        }
+
+    @mcp.tool()
+    def email_loeschen(email_id: str, bestaetigung: bool = False) -> dict:
+        """Loescht eine E-Mail aus der Datenbank (#445).
+
+        Args:
+            email_id: ID der E-Mail
+            bestaetigung: Muss True sein um tatsaechlich zu loeschen
+        """
+        profile_id = db.get_active_profile_id()
+        email = db.get_email(email_id, profile_id=profile_id)
+        if not email:
+            return {"fehler": "E-Mail nicht gefunden."}
+        if not bestaetigung:
+            return {
+                "status": "bestaetigung_erforderlich",
+                "email_id": email_id,
+                "betreff": email.get("subject", ""),
+                "hinweis": "Setze bestaetigung=True um die E-Mail unwiderruflich zu loeschen.",
+            }
+        deleted = db.delete_email(email_id, profile_id=profile_id)
+        if not deleted:
+            return {"fehler": "E-Mail konnte nicht geloescht werden."}
+        return {"status": "geloescht", "email_id": email_id}
+
+    @mcp.tool()
+    def emails_anzeigen(bewerbung_id: str = "") -> dict:
+        """Zeigt E-Mails — entweder zu einer Bewerbung oder alle nicht zugeordneten (#445).
+
+        Args:
+            bewerbung_id: Optional — wenn gesetzt, nur E-Mails dieser Bewerbung.
+                          Leer = alle noch nicht zugeordneten E-Mails (unmatched).
+        """
+        profile_id = db.get_active_profile_id()
+        if bewerbung_id:
+            app = db.get_application(bewerbung_id)
+            if not app:
+                return {"fehler": "Bewerbung nicht gefunden."}
+            emails = db.get_emails_for_application(bewerbung_id, profile_id=profile_id)
+            return {
+                "status": "ok",
+                "bewerbung": f"{app.get('title', '')} bei {app.get('company', '')}",
+                "anzahl": len(emails),
+                "emails": emails,
+            }
+        emails = db.get_unmatched_emails()
+        return {
+            "status": "ok",
+            "filter": "unmatched",
+            "anzahl": len(emails),
+            "emails": emails,
+        }

--- a/src/bewerbungs_assistent/tools/dokumente.py
+++ b/src/bewerbungs_assistent/tools/dokumente.py
@@ -1162,3 +1162,102 @@ def register(mcp, db, logger):
             "nachricht": f"Profil importiert und aktiviert. "
                          "Das vorherige Profil wurde gespeichert und kann mit profil_wechseln() wieder aktiviert werden.",
         }
+
+    # === Dokument-Write-Tools (#447) =======================================
+    # Schreibzugriff auf Dokumente: Entverknuepfen, Loeschen, Status setzen.
+    # Bisher konnte Claude diese Operationen nur per direktem SQL ausfuehren.
+
+    _DOC_STATUS_VALUES = {"nicht_extrahiert", "gestartet", "extrahiert", "angewendet"}
+
+    @mcp.tool()
+    def dokument_entverknuepfen(dokument_id: str) -> dict:
+        """Entfernt die Verknuepfung eines Dokuments zu einer Bewerbung (#447).
+
+        Nutze dies, wenn eine automatische oder manuelle Zuordnung falsch ist
+        und das Dokument wieder 'unverknuepft' erscheinen soll. Das Dokument
+        selbst bleibt erhalten — nur die Verknuepfung wird geloest.
+
+        Args:
+            dokument_id: ID des Dokuments
+        """
+        profile_id = db.get_active_profile_id()
+        doc = db.get_document(dokument_id, profile_id=profile_id)
+        if not doc:
+            return {"fehler": "Dokument nicht gefunden."}
+        if not doc.get("linked_application_id"):
+            return {
+                "status": "nicht_verknuepft",
+                "hinweis": "Das Dokument war bereits keiner Bewerbung zugeordnet.",
+            }
+        changed = db.relink_document(dokument_id, None, profile_id=profile_id)
+        if not changed:
+            return {"fehler": "Verknuepfung konnte nicht entfernt werden."}
+        return {
+            "status": "entverknuepft",
+            "dokument_id": dokument_id,
+            "dokument": doc.get("filename", ""),
+            "nachricht": (
+                f"Dokument '{doc.get('filename', '')}' ist nicht mehr mit einer "
+                "Bewerbung verknuepft."
+            ),
+        }
+
+    @mcp.tool()
+    def dokument_loeschen(dokument_id: str, bestaetigung: bool = False) -> dict:
+        """Loescht ein Dokument komplett — DB-Eintrag und physische Datei (#447).
+
+        ACHTUNG: Nicht rueckgaengig zu machen. Beim ersten Aufruf ohne
+        Bestaetigung wird nur eine Rueckfrage zurueckgegeben.
+
+        Args:
+            dokument_id: ID des Dokuments
+            bestaetigung: Muss True sein um tatsaechlich zu loeschen
+        """
+        profile_id = db.get_active_profile_id()
+        doc = db.get_document(dokument_id, profile_id=profile_id)
+        if not doc:
+            return {"fehler": "Dokument nicht gefunden."}
+        if not bestaetigung:
+            return {
+                "status": "bestaetigung_erforderlich",
+                "dokument_id": dokument_id,
+                "dokument": doc.get("filename", ""),
+                "hinweis": "Setze bestaetigung=True um Dokument und Datei unwiderruflich zu loeschen.",
+            }
+        deleted = db.delete_document(dokument_id, profile_id=profile_id)
+        if not deleted:
+            return {"fehler": "Dokument konnte nicht geloescht werden."}
+        return {
+            "status": "geloescht",
+            "dokument_id": dokument_id,
+            "nachricht": f"Dokument '{doc.get('filename', '')}' wurde geloescht.",
+        }
+
+    @mcp.tool()
+    def dokument_status_setzen(dokument_id: str, status: str) -> dict:
+        """Setzt den Extraktions-Status eines Dokuments manuell (#447).
+
+        Nutze dies z.B. nachdem du eine tiefere Analyse abgeschlossen hast und
+        das Dokument als 'angewendet' markieren willst, ohne `extraktion_anwenden`
+        noch einmal durchlaufen zu lassen.
+
+        Args:
+            dokument_id: ID des Dokuments
+            status: nicht_extrahiert, gestartet, extrahiert, angewendet
+        """
+        if status not in _DOC_STATUS_VALUES:
+            return {
+                "fehler": f"Ungueltiger Status '{status}'.",
+                "erlaubte_status": sorted(_DOC_STATUS_VALUES),
+            }
+        profile_id = db.get_active_profile_id()
+        doc = db.get_document(dokument_id, profile_id=profile_id)
+        if not doc:
+            return {"fehler": "Dokument nicht gefunden."}
+        db.update_document_extraction_status(dokument_id, status)
+        return {
+            "status": "aktualisiert",
+            "dokument_id": dokument_id,
+            "extraction_status": status,
+            "nachricht": f"Dokument '{doc.get('filename', '')}' -> {status}.",
+        }

--- a/src/bewerbungs_assistent/tools/jobs.py
+++ b/src/bewerbungs_assistent/tools/jobs.py
@@ -1,4 +1,4 @@
-"""Jobsuche und Stellenverwaltung — 6 Tools."""
+"""Jobsuche und Stellenverwaltung — 7 Tools (#446: stelle_bearbeiten)."""
 
 import threading
 
@@ -781,3 +781,55 @@ def register(mcp, db, logger):
         if job_dict.get("veroeffentlicht_am"):
             result["veroeffentlicht_am"] = job_dict["veroeffentlicht_am"]
         return result
+
+    @mcp.tool()
+    def stelle_bearbeiten(
+        job_hash: str,
+        titel: str = "",
+        firma: str = "",
+        ort: str = "",
+        beschreibung: str = "",
+    ) -> dict:
+        """Aktualisiert Felder einer bestehenden Stelle (#446).
+
+        Nutze dies, um eine gescrapte oder manuell angelegte Stelle
+        nachtraeglich zu korrigieren oder zu verfeinern — z.B. wenn aus einer
+        E-Mail eine ausfuehrlichere Beschreibung hervorgeht oder die
+        Ortsangabe prezisiert werden muss.
+
+        Nur angegebene Felder werden geaendert. Leere Strings bleiben unveraendert.
+
+        Args:
+            job_hash: Hash der Stelle (aus stellen_anzeigen)
+            titel: Neuer Stellentitel
+            firma: Neuer Firmenname
+            ort: Neuer Arbeitsort
+            beschreibung: Neue Stellenbeschreibung
+        """
+        job = db.get_job(job_hash)
+        if not job:
+            return {"fehler": "Stelle nicht gefunden. Pruefe den Hash mit stellen_anzeigen()."}
+
+        updates: dict = {}
+        if titel:
+            updates["title"] = titel
+        if firma:
+            updates["company"] = firma
+        if ort:
+            updates["location"] = ort
+        if beschreibung:
+            updates["description"] = beschreibung
+
+        if not updates:
+            return {"fehler": "Keine Aenderungen angegeben."}
+
+        db.update_job(job_hash, updates)
+        return {
+            "status": "aktualisiert",
+            "job_hash": job_hash,
+            "geaenderte_felder": list(updates.keys()),
+            "nachricht": (
+                f"Stelle '{updates.get('title') or job.get('title', '')}' "
+                f"bei {updates.get('company') or job.get('company', '')} aktualisiert."
+            ),
+        }

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -91,6 +91,18 @@ EXPECTED_TOOL_NAMES = {
     "keyword_vorschlaege",
     "pbp_diagnose",
     "recherche_speichern",
+    # v1.5.4: Write-Back-Gaps (#443-#448)
+    "meeting_hinzufuegen",
+    "meeting_bearbeiten",
+    "meeting_loeschen",
+    "meetings_anzeigen",
+    "email_verknuepfen",
+    "email_loeschen",
+    "emails_anzeigen",
+    "stelle_bearbeiten",
+    "dokument_entverknuepfen",
+    "dokument_loeschen",
+    "dokument_status_setzen",
 }
 
 EXPECTED_PROMPT_NAMES = {
@@ -184,7 +196,7 @@ def test_mcp_registry_counts(tmp_path):
     mcp, db = _build_test_server(tmp_path)
     try:
         tools, prompts, resources = _collect_names(mcp)
-        assert len(tools) == 73
+        assert len(tools) == 84  # v1.5.4: +11 Write-Back-Tools (#443)
         assert len(prompts) == 18
         assert len(resources) == 6
     finally:

--- a/tests/test_v154_writeback.py
+++ b/tests/test_v154_writeback.py
@@ -1,0 +1,408 @@
+"""Regressionstests fuer v1.5.4 Write-Back-Tools (#443).
+
+Deckt alle neuen MCP-Tools ab die in #444-#448 ergaenzt wurden:
+
+- Meetings: meeting_hinzufuegen, meeting_bearbeiten, meeting_loeschen, meetings_anzeigen
+- E-Mails: email_verknuepfen, email_loeschen, emails_anzeigen
+- Jobs: stelle_bearbeiten
+- Dokumente: dokument_entverknuepfen, dokument_loeschen, dokument_status_setzen
+- Bewerbungen: bewerbung_bearbeiten um cover_letter_path/cv_path erweitert
+"""
+
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+
+from fastmcp import FastMCP
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from bewerbungs_assistent.database import Database  # noqa: E402
+from bewerbungs_assistent.tools import register_all  # noqa: E402
+
+
+def _build_server(tmp_path):
+    os.environ["BA_DATA_DIR"] = str(tmp_path)
+    db = Database(db_path=tmp_path / "test.db")
+    db.initialize()
+    db.save_profile({"name": "Write-Back Tester", "email": "wb@example.com"})
+    mcp = FastMCP("PBP v1.5.4 Test")
+    logger = logging.getLogger("test.writeback")
+    register_all(mcp, db, logger)
+    return mcp, db
+
+
+async def _call(mcp, name, args=None):
+    result = await mcp.call_tool(name, args or {})
+    if hasattr(result, "structured_content") and result.structured_content:
+        return result.structured_content
+    import json
+    for c in getattr(result, "content", []):
+        if hasattr(c, "text"):
+            try:
+                return json.loads(c.text)
+            except (json.JSONDecodeError, TypeError):
+                return {"text": c.text}
+    return {}
+
+
+def _run(mcp, name, args=None):
+    return asyncio.run(_call(mcp, name, args or {}))
+
+
+def _seed_application(db, title="Senior Dev", company="Acme GmbH") -> str:
+    return db.add_application({"title": title, "company": company, "url": "https://acme.example/jobs/1"})
+
+
+def _seed_job(db, title="Senior Dev", company="Acme GmbH") -> str:
+    from bewerbungs_assistent.job_scraper import stelle_hash
+    h = stelle_hash("manuell", f"{company} {title}")
+    db.save_jobs([{
+        "hash": h, "title": title, "company": company, "location": "Hamburg",
+        "url": "https://acme.example/jobs/1", "description": "Alt",
+        "source": "manuell", "remote": "hybrid",
+    }])
+    return h
+
+
+def _seed_document(db, filename="lebenslauf.pdf", doc_type="lebenslauf") -> str:
+    """Legt ein Dokument in der DB an ohne physische Datei."""
+    return db.add_document({
+        "filename": filename,
+        "filepath": "",  # keine echte Datei
+        "doc_type": doc_type,
+    })
+
+
+# ==================== Meetings (#444) ====================
+
+def test_meeting_hinzufuegen_success(tmp_path):
+    mcp, db = _build_server(tmp_path)
+    try:
+        app_id = _seed_application(db)
+        result = _run(mcp, "meeting_hinzufuegen", {
+            "bewerbung_id": app_id,
+            "datum": "2026-04-18T14:00",
+            "typ": "interview",
+            "platform": "Teams",
+            "notizen": "Erstes Gespraech mit HR",
+            "dauer_minuten": 60,
+        })
+        assert result.get("status") == "angelegt", result
+        assert "meeting_id" in result
+        # Persistenz pruefen
+        meetings = db.get_meetings_for_application(app_id, profile_id=db.get_active_profile_id())
+        assert len(meetings) == 1
+        assert meetings[0]["meeting_type"] == "interview"
+        assert meetings[0]["platform"] == "Teams"
+        assert meetings[0]["duration_minutes"] == 60
+    finally:
+        db.close()
+        os.environ.pop("BA_DATA_DIR", None)
+
+
+def test_meeting_hinzufuegen_invalid_bewerbung(tmp_path):
+    mcp, db = _build_server(tmp_path)
+    try:
+        result = _run(mcp, "meeting_hinzufuegen", {
+            "bewerbung_id": "nicht-da",
+            "datum": "2026-04-18T14:00",
+        })
+        assert "fehler" in result
+    finally:
+        db.close()
+        os.environ.pop("BA_DATA_DIR", None)
+
+
+def test_meeting_hinzufuegen_invalid_typ(tmp_path):
+    mcp, db = _build_server(tmp_path)
+    try:
+        app_id = _seed_application(db)
+        result = _run(mcp, "meeting_hinzufuegen", {
+            "bewerbung_id": app_id,
+            "datum": "2026-04-18T14:00",
+            "typ": "quatsch",
+        })
+        assert "fehler" in result
+        assert "erlaubte_typen" in result
+    finally:
+        db.close()
+        os.environ.pop("BA_DATA_DIR", None)
+
+
+def test_meeting_bearbeiten_updates_fields(tmp_path):
+    mcp, db = _build_server(tmp_path)
+    try:
+        app_id = _seed_application(db)
+        created = _run(mcp, "meeting_hinzufuegen", {
+            "bewerbung_id": app_id,
+            "datum": "2026-04-18T14:00",
+            "typ": "telefon",
+        })
+        mid = created["meeting_id"]
+        result = _run(mcp, "meeting_bearbeiten", {
+            "meeting_id": mid,
+            "status": "bestaetigt",
+            "notizen": "verschoben auf 15 Uhr",
+        })
+        assert result.get("status") == "aktualisiert"
+        assert set(result["geaenderte_felder"]) == {"status", "notes"}
+        meetings = db.get_meetings_for_application(app_id, profile_id=db.get_active_profile_id())
+        assert meetings[0]["status"] == "bestaetigt"
+        assert meetings[0]["notes"] == "verschoben auf 15 Uhr"
+    finally:
+        db.close()
+        os.environ.pop("BA_DATA_DIR", None)
+
+
+def test_meeting_bearbeiten_empty_update(tmp_path):
+    mcp, db = _build_server(tmp_path)
+    try:
+        app_id = _seed_application(db)
+        created = _run(mcp, "meeting_hinzufuegen", {
+            "bewerbung_id": app_id, "datum": "2026-04-18T14:00",
+        })
+        result = _run(mcp, "meeting_bearbeiten", {"meeting_id": created["meeting_id"]})
+        assert "fehler" in result
+    finally:
+        db.close()
+        os.environ.pop("BA_DATA_DIR", None)
+
+
+def test_meeting_loeschen_two_phase(tmp_path):
+    mcp, db = _build_server(tmp_path)
+    try:
+        app_id = _seed_application(db)
+        created = _run(mcp, "meeting_hinzufuegen", {
+            "bewerbung_id": app_id, "datum": "2026-04-18T14:00",
+        })
+        mid = created["meeting_id"]
+        # Phase 1: ohne Bestaetigung
+        r1 = _run(mcp, "meeting_loeschen", {"meeting_id": mid})
+        assert r1["status"] == "bestaetigung_erforderlich"
+        # Meeting muss noch da sein
+        assert len(db.get_meetings_for_application(app_id, profile_id=db.get_active_profile_id())) == 1
+        # Phase 2: mit Bestaetigung
+        r2 = _run(mcp, "meeting_loeschen", {"meeting_id": mid, "bestaetigung": True})
+        assert r2["status"] == "geloescht"
+        assert db.get_meetings_for_application(app_id, profile_id=db.get_active_profile_id()) == []
+    finally:
+        db.close()
+        os.environ.pop("BA_DATA_DIR", None)
+
+
+def test_meetings_anzeigen_filtered_and_upcoming(tmp_path):
+    mcp, db = _build_server(tmp_path)
+    try:
+        app_id = _seed_application(db)
+        _run(mcp, "meeting_hinzufuegen", {
+            "bewerbung_id": app_id, "datum": "2099-12-31T10:00", "typ": "interview",
+        })
+        # Filter nach Bewerbung
+        r1 = _run(mcp, "meetings_anzeigen", {"bewerbung_id": app_id})
+        assert r1["anzahl"] == 1
+        # Kommende Termine global
+        r2 = _run(mcp, "meetings_anzeigen", {"tage": 36500})
+        assert r2["anzahl"] == 1
+    finally:
+        db.close()
+        os.environ.pop("BA_DATA_DIR", None)
+
+
+# ==================== E-Mails (#445) ====================
+
+def test_email_verknuepfen_and_unlink(tmp_path):
+    mcp, db = _build_server(tmp_path)
+    try:
+        app_id = _seed_application(db)
+        email_id = db.add_email({
+            "filename": "antwort.eml",
+            "subject": "Vielen Dank fuer Ihre Bewerbung",
+            "sender": "hr@acme.example",
+            "direction": "eingang",
+        })
+        # Verknuepfen
+        r1 = _run(mcp, "email_verknuepfen", {"email_id": email_id, "bewerbung_id": app_id})
+        assert r1["status"] == "verknuepft"
+        stored = db.get_email(email_id, profile_id=db.get_active_profile_id())
+        assert stored["application_id"] == app_id
+        # Entkoppeln durch leere bewerbung_id
+        r2 = _run(mcp, "email_verknuepfen", {"email_id": email_id, "bewerbung_id": ""})
+        assert r2["status"] == "entkoppelt"
+        stored = db.get_email(email_id, profile_id=db.get_active_profile_id())
+        assert stored["application_id"] is None
+    finally:
+        db.close()
+        os.environ.pop("BA_DATA_DIR", None)
+
+
+def test_email_loeschen_two_phase(tmp_path):
+    mcp, db = _build_server(tmp_path)
+    try:
+        email_id = db.add_email({"filename": "spam.eml", "subject": "Test"})
+        r1 = _run(mcp, "email_loeschen", {"email_id": email_id})
+        assert r1["status"] == "bestaetigung_erforderlich"
+        assert db.get_email(email_id, profile_id=db.get_active_profile_id()) is not None
+        r2 = _run(mcp, "email_loeschen", {"email_id": email_id, "bestaetigung": True})
+        assert r2["status"] == "geloescht"
+        assert db.get_email(email_id, profile_id=db.get_active_profile_id()) is None
+    finally:
+        db.close()
+        os.environ.pop("BA_DATA_DIR", None)
+
+
+def test_emails_anzeigen_unmatched(tmp_path):
+    mcp, db = _build_server(tmp_path)
+    try:
+        db.add_email({"filename": "a.eml", "subject": "Unmatched 1"})
+        db.add_email({"filename": "b.eml", "subject": "Unmatched 2"})
+        app_id = _seed_application(db)
+        matched_id = db.add_email({"filename": "c.eml", "subject": "Matched", "application_id": app_id})
+        r = _run(mcp, "emails_anzeigen", {})
+        assert r["filter"] == "unmatched"
+        assert r["anzahl"] == 2
+        r2 = _run(mcp, "emails_anzeigen", {"bewerbung_id": app_id})
+        assert r2["anzahl"] == 1
+        assert r2["emails"][0]["id"] == matched_id
+    finally:
+        db.close()
+        os.environ.pop("BA_DATA_DIR", None)
+
+
+# ==================== Jobs (#446) ====================
+
+def test_stelle_bearbeiten_updates_fields(tmp_path):
+    mcp, db = _build_server(tmp_path)
+    try:
+        h = _seed_job(db)
+        result = _run(mcp, "stelle_bearbeiten", {
+            "job_hash": h,
+            "titel": "Senior Dev (m/w/d) — REMOTE",
+            "beschreibung": "Neue, deutlich ausfuehrlichere Beschreibung.",
+        })
+        assert result["status"] == "aktualisiert"
+        assert set(result["geaenderte_felder"]) == {"title", "description"}
+        job = db.get_job(h)
+        assert job["title"] == "Senior Dev (m/w/d) — REMOTE"
+        assert "ausfuehrlichere" in job["description"]
+    finally:
+        db.close()
+        os.environ.pop("BA_DATA_DIR", None)
+
+
+def test_stelle_bearbeiten_unknown_hash(tmp_path):
+    mcp, db = _build_server(tmp_path)
+    try:
+        result = _run(mcp, "stelle_bearbeiten", {"job_hash": "nope", "titel": "X"})
+        assert "fehler" in result
+    finally:
+        db.close()
+        os.environ.pop("BA_DATA_DIR", None)
+
+
+def test_stelle_bearbeiten_empty_update(tmp_path):
+    mcp, db = _build_server(tmp_path)
+    try:
+        h = _seed_job(db)
+        result = _run(mcp, "stelle_bearbeiten", {"job_hash": h})
+        assert "fehler" in result
+    finally:
+        db.close()
+        os.environ.pop("BA_DATA_DIR", None)
+
+
+# ==================== Dokumente (#447) ====================
+
+def test_dokument_entverknuepfen(tmp_path):
+    mcp, db = _build_server(tmp_path)
+    try:
+        app_id = _seed_application(db)
+        doc_id = _seed_document(db)
+        # Erst verknuepfen per DB-Helper, dann via Tool wieder loesen
+        assert db.link_document_to_application(doc_id, app_id, profile_id=db.get_active_profile_id())
+        result = _run(mcp, "dokument_entverknuepfen", {"dokument_id": doc_id})
+        assert result["status"] == "entverknuepft"
+        doc = db.get_document(doc_id, profile_id=db.get_active_profile_id())
+        assert doc["linked_application_id"] is None
+    finally:
+        db.close()
+        os.environ.pop("BA_DATA_DIR", None)
+
+
+def test_dokument_entverknuepfen_already_unlinked(tmp_path):
+    mcp, db = _build_server(tmp_path)
+    try:
+        doc_id = _seed_document(db)
+        result = _run(mcp, "dokument_entverknuepfen", {"dokument_id": doc_id})
+        assert result["status"] == "nicht_verknuepft"
+    finally:
+        db.close()
+        os.environ.pop("BA_DATA_DIR", None)
+
+
+def test_dokument_loeschen_two_phase(tmp_path):
+    mcp, db = _build_server(tmp_path)
+    try:
+        doc_id = _seed_document(db, filename="obsolet.pdf")
+        r1 = _run(mcp, "dokument_loeschen", {"dokument_id": doc_id})
+        assert r1["status"] == "bestaetigung_erforderlich"
+        assert db.get_document(doc_id, profile_id=db.get_active_profile_id()) is not None
+        r2 = _run(mcp, "dokument_loeschen", {"dokument_id": doc_id, "bestaetigung": True})
+        assert r2["status"] == "geloescht"
+        assert db.get_document(doc_id, profile_id=db.get_active_profile_id()) is None
+    finally:
+        db.close()
+        os.environ.pop("BA_DATA_DIR", None)
+
+
+def test_dokument_status_setzen(tmp_path):
+    mcp, db = _build_server(tmp_path)
+    try:
+        doc_id = _seed_document(db)
+        result = _run(mcp, "dokument_status_setzen", {
+            "dokument_id": doc_id, "status": "angewendet",
+        })
+        assert result["status"] == "aktualisiert"
+        assert result["extraction_status"] == "angewendet"
+        doc = db.get_document(doc_id, profile_id=db.get_active_profile_id())
+        assert doc["extraction_status"] == "angewendet"
+    finally:
+        db.close()
+        os.environ.pop("BA_DATA_DIR", None)
+
+
+def test_dokument_status_setzen_invalid(tmp_path):
+    mcp, db = _build_server(tmp_path)
+    try:
+        doc_id = _seed_document(db)
+        result = _run(mcp, "dokument_status_setzen", {
+            "dokument_id": doc_id, "status": "quatsch",
+        })
+        assert "fehler" in result
+        assert "erlaubte_status" in result
+    finally:
+        db.close()
+        os.environ.pop("BA_DATA_DIR", None)
+
+
+# ==================== Bewerbungen (#448) ====================
+
+def test_bewerbung_bearbeiten_cover_letter_and_cv(tmp_path):
+    mcp, db = _build_server(tmp_path)
+    try:
+        app_id = _seed_application(db)
+        result = _run(mcp, "bewerbung_bearbeiten", {
+            "bewerbung_id": app_id,
+            "cover_letter_path": "/tmp/anschreiben.pdf",
+            "cv_path": "/tmp/cv.pdf",
+        })
+        assert result["status"] == "aktualisiert"
+        assert set(result["geänderte_felder"]) == {"cover_letter_path", "cv_path"}
+        app = db.get_application(app_id)
+        assert app["cover_letter_path"] == "/tmp/anschreiben.pdf"
+        assert app["cv_path"] == "/tmp/cv.pdf"
+    finally:
+        db.close()
+        os.environ.pop("BA_DATA_DIR", None)


### PR DESCRIPTION
## Summary

- **11 neue MCP-Tools** fuer Meetings, Emails, Stellen-Korrekturen und Dokument-Pflege — schliesst die letzten Luecken, an denen Claude auf direktes SQL ausweichen musste
- **`bewerbung_bearbeiten`** um `cover_letter_path` und `cv_path` erweitert (#448)
- **Oeffentliche MCP-Schnittstelle waechst von 73 auf 84 Tools**
- **19 neue Regressionstests**, volle Suite 429 passing

Closes #443, #444, #445, #446, #447, #448

## Neue Tools

- **Meetings** (#444): `meeting_hinzufuegen`, `meeting_bearbeiten`, `meeting_loeschen`, `meetings_anzeigen`
- **Emails** (#445): `email_verknuepfen`, `email_loeschen`, `emails_anzeigen`
- **Stellen** (#446): `stelle_bearbeiten`
- **Dokumente** (#447): `dokument_entverknuepfen`, `dokument_loeschen`, `dokument_status_setzen`

## Zusaetzliche Fixes (Release-Hygiene)

- `pytest testpaths=["tests"]` — verhindert, dass pytest das Dashboard-Launcher-Script `test_demo.py` einsammelt und beim Uvicorn-Start haengt
- README-Badge 401 → 429 (stand schon seit v1.5.3 veraltet)
- `__init__.py` Version-Bump 1.5.3 → 1.5.4

## Test plan

- [x] Neue Regressionstests fuer alle 11 Tools laufen gruen (`tests/test_v154_writeback.py`)
- [x] `test_mcp_registry` prueft 84 Tools + stabile Namen
- [x] Volle pytest-Suite aus Projekt-Root: 429 passing, 0 failing
- [x] `release_check.py` alle 5 Gates gruen
- [ ] Manuelles Anwender-Smoketest nach Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)