### PR TITLE
beta.103: User-Test-Welle — DB-Lock-Haertung, ehrliches Dedup-Gate, Update-Banner (#704/#705/#708-#711)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,98 @@ Sektionen: **Added** (neue Features), **Changed** (bestehendes geändert),
 > Emails → `<email-anonymisiert>`). Praeventiv-Werkzeug:
 > `scripts/scrub_pii.py`. Pflicht-Workflow in CLAUDE.md dokumentiert.
 
+## [1.7.0-beta.103] - 2026-06-12 — User-Test-Welle: DB-Lock-Haertung, ehrliches Dedup-Gate, Update-Banner (#704, #705, #708-#711)
+
+> ⚠️ **Pre-Release / Beta**. Stable bleibt **v1.6.10**. Kein Frontend-Build
+> noetig, keine Schema-Aenderung (bleibt v46). Nach dem Update Claude Desktop
+> einmal komplett beenden und neu starten.
+
+Fixes aus dem laufenden Abschlusstest (Stellen-Triage 11./12.06.).
+
+### Fixed
+
+- **#708 — „database is locked" bis zum Neustart (kritisch):** Der
+  Haupt-Connection fehlte `busy_timeout` (Writes scheiterten sofort, statt
+  kurz zu warten), und ein per Timeout abgebrochenes Tool konnte eine offene
+  Transaktion hinterlassen, die den Write-Lock dauerhaft hielt. Jetzt:
+  `busy_timeout=5000` + Rollback-Sicherheitsnetz an den Ausfuehrungs-Grenzen
+  (Tool-Middleware + Auto-Engine-Zyklus) mit WARNING-Log.
+- **#709 — Dedup-Override war eine Luege:** Die Fehlermeldung versprach einen
+  `notes`-Bypass, der **nie implementiert** war. Jetzt gibt es den ehrlichen
+  Parameter `force=True` in `bewerbung_erstellen`; alle Duplikat-Meldungen
+  nennen ihn.
+- **#710 — `endkunde` in `bewerbung_erstellen`:** Die DB-Spalte existierte
+  seit Schema v14, wurde aber nie durchgereicht. Bei gesetztem Endkunden
+  trennt die Duplikat-Erkennung jetzt Vermittler-Engagements (gleicher
+  Vermittler + anderer Endkunde ≠ Duplikat).
+- **#711 — Release-Banner ist wieder ein Update-Hinweis:** Das Dashboard
+  zeigte beta.102-Nutzern „Neu in beta.101". Release-Hints werden jetzt nur
+  noch angezeigt, wenn die angekuendigte Version NEUER ist als die
+  installierte (korrekter Versionsvergleich, Stable > Beta).
+- **#705 — Profil-Datenverlust-Haertung:** `pbp_diagnose` erkennt jetzt das
+  Muster „gepflegtes Profil, aber Kontaktfelder/Notizen leer" und zeigt den
+  Wiederherstellungs-Weg aus `data/backups/`. (Die Ursache des gemeldeten
+  Verlusts — der `profil_erstellen`-Ueberschreib-Bug — ist seit beta.101
+  gefixt; Migrationen selbst leeren keine Felder, sie sind ALTER-only.)
+
+### Changed
+
+- **#704 — Jobsuche-Workflow schliesst manuelle Quellen ein:** Claude wird im
+  gefuehrten Workflow angewiesen, LinkedIn/XING/StepStone/Google Jobs ohne
+  Nachfrage via Claude-in-Chrome abzuarbeiten (sofern verbunden) und Treffer
+  direkt mit `stelle_manuell_anlegen()` zu erfassen.
+
+### Unter der Haube
+
+Neue Regressionstests `test_v17_user_test_703plus` (9 Tests). Keine
+Schema-/Frontend-Aenderung. #706 (Interview-Button) und #707
+(Notizen-Pflege) sind als G16/H15 im Master-Plan eingeplant.
+
+---
+
+## 📦 Wie installiere oder aktualisiere ich PBP?
+
+**Unter Windows** brauchst du kein Git, kein Python, kein Vorwissen — nur einen ZIP-Download und einen Doppelklick. **Unter macOS** muss vorher einmalig Python 3.11+ installiert sein, **unter Linux** Git und Python. Voraussetzung ueberall: [Claude Desktop](https://claude.ai/download) ist installiert (Linux: alternativ Claude Code CLI).
+
+### Windows (empfohlen, bequemster Weg)
+
+1. **ZIP herunterladen:** [PBP-1.7.0-beta.103.zip](https://github.com/MadGapun/PBP/archive/refs/tags/v1.7.0-beta.103.zip)
+2. **Entpacken:** Rechtsklick auf die ZIP → *„Alle extrahieren..."* → Zielordner waehlen (z.B. `C:\PBP`). Darin liegt ein Unterordner `PBP-...` — dort hinein wechseln.
+3. **Installieren:** Doppelklick auf **`INSTALLIEREN.bat`**
+4. Das Setup laedt Python, alle Pakete und Chromium herunter (~3–5 Minuten) und konfiguriert Claude Desktop.
+5. Auf dem Desktop liegt jetzt eine Verknuepfung **„PBP Bewerbungs-Portal"** — Doppelklick startet das Dashboard.
+6. **Claude Desktop oeffnen** (lief es schon: komplett beenden — Rechtsklick aufs Claude-Symbol unten rechts in der Taskleiste → *Beenden* — und neu starten) und tippen: **„Starte die Ersterfassung"**
+7. Taucht PBP nicht auf: Claude Desktop nochmal komplett beenden und neu starten — siehe [FAQ](https://github.com/MadGapun/PBP/wiki/FAQ).
+
+### macOS
+
+1. **Einmalig vorab: Python 3.11+** — am einfachsten der [Installer von python.org](https://www.python.org/downloads/) (Doppelklick), alternativ `brew install python@3.12`
+2. **ZIP herunterladen** (siehe Windows-Link) und **entpacken** (Doppelklick; im ZIP liegt ein Unterordner `PBP-...`)
+3. **Doppelklick auf `INSTALLIEREN.command`**
+4. Falls macOS warnt („kann nicht geoeffnet werden"): Rechtsklick auf die Datei → *„Oeffnen"* → nochmal *„Oeffnen"*
+
+### Linux
+
+```bash
+git clone https://github.com/MadGapun/PBP.git
+cd PBP
+bash installer/install.sh
+```
+
+### Update von einer aelteren Version
+
+**Einfach drueberinstallieren** — deine Daten bleiben erhalten:
+- Windows: `%LOCALAPPDATA%\BewerbungsAssistent\data\pbp.db`
+- macOS/Linux: `~/.bewerbungs-assistent/pbp.db`
+
+Schema-Upgrade laeuft automatisch beim ersten Start, ein Backup wird vorher erstellt (Ordner `data\backups\`).
+
+### Detaillierte Anleitung & Troubleshooting
+
+📖 [Wiki → Installation](https://github.com/MadGapun/PBP/wiki/Installation) · [FAQ](https://github.com/MadGapun/PBP/wiki/FAQ)
+
+---
+
 ## [1.7.0-beta.102] - 2026-06-10 — Feinschliff aus der Dashboard-Tour (#702)
 
 > ⚠️ **Pre-Release / Beta**. Stable bleibt **v1.6.10**. Neuer Frontend-Build,

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![MCP](https://img.shields.io/badge/MCP-Claude_Desktop-orange.svg)](https://modelcontextprotocol.io/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Stable](https://img.shields.io/badge/Stable-v1.6.10-brightgreen.svg)](https://github.com/MadGapun/PBP/releases/latest)
-[![Tests](https://img.shields.io/badge/Tests-1715-brightgreen.svg)](#tests)
+[![Tests](https://img.shields.io/badge/Tests-1724-brightgreen.svg)](#tests)
 [![Tools](https://img.shields.io/badge/MCP_Tools-177-blueviolet.svg)](https://github.com/MadGapun/PBP/wiki/MCP-Tools)
 [![Workflows](https://img.shields.io/badge/Workflows-18-ff69b4.svg)](https://github.com/MadGapun/PBP/wiki/Workflows)
 [![Plattformen](https://img.shields.io/badge/Plattformen-Windows_%7C_macOS_%7C_Linux-blue.svg)](#schnellstart)
@@ -202,7 +202,7 @@ Claude führt dich durch ein lockeres Gespräch (ca. 10-15 Minuten) und baut dei
 | **Jobportale** | 35 Quellen konfiguriert (~6 aktuell zuverlaessig liefernd, u.a. Bundesagentur, Hays, Greenhouse, Arbeitnow, JobSpy-Indeed; defekte sichtbar markiert mit Chrome-Workaround) |
 | **Dashboard** | 8 Tabs: Dashboard, Profil, Stellen, Bewerbungen, Dokumente, Kalender, Statistiken, Einstellungen |
 | **Datenbank** | SQLite (WAL), Schema v46 |
-| **Tests** | 1714 bestanden (1 uebersprungen) |
+| **Tests** | 1723 bestanden (1 uebersprungen) |
 
 ### Typed IDs (v1.7.0, #505)
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.7.0-beta.102",
+  "version": "1.7.0-beta.103",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/hints.json
+++ b/hints.json
@@ -7,7 +7,8 @@
       "text": "Grosser Stabilisierungs-Release: 13 Bugfixes (u.a. Jobsuche haengt nicht mehr bei 0%, Profil-Daten bleiben beim Aktualisieren erhalten, Blacklist warnt vor laufenden Interview-Bewerbungen), Dashboard trennt Termine von Erinnerungen, ehrlichere Meldungen fuer Einsteiger.",
       "url": "https://github.com/MadGapun/PBP/releases/latest",
       "url_label": "Release-Notes ansehen",
-      "min_version": "1.7.0"
+      "min_version": "1.7.0",
+      "version": "1.7.0-beta.101"
     }
   ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bewerbungs-assistent"
-version = "1.7.0b102"
+version = "1.7.0b103"
 description = "PBP — KI-gestuetzter Bewerbungsassistent als MCP-Server fuer Claude Desktop. Stellensuche, Bewerbungs-Tracking, Lebenslauf-/Anschreiben-Generierung, Interview-Coaching."
 readme = "README.md"
 license = "MIT"

--- a/src/bewerbungs_assistent/__init__.py
+++ b/src/bewerbungs_assistent/__init__.py
@@ -1,6 +1,6 @@
 """Bewerbungs-Assistent - KI-gestützter MCP Server für Claude Desktop."""
 
-__version__ = "1.7.0-beta.102"
+__version__ = "1.7.0-beta.103"
 
 
 def main():

--- a/src/bewerbungs_assistent/dashboard.py
+++ b/src/bewerbungs_assistent/dashboard.py
@@ -340,6 +340,21 @@ async def api_status():
 
 
 
+def _version_tuple(v: str) -> tuple:
+    """#711: '1.7.0-beta.101' -> (1, 7, 0, 0, 101); '1.7.0' -> (1, 7, 0, 1, 0).
+
+    Das vierte Element (Stable-Flag) sorgt dafuer, dass ein Stable-Release
+    NEUER ist als jede Beta derselben Versionsnummer.
+    """
+    import re
+    s = str(v or "").strip()
+    nums = [int(x) for x in re.findall(r"\d+", s)]
+    is_beta = "beta" in s.lower() or "rc" in s.lower() or "a" == s.lower()[-1:]
+    base = nums[:3] + [0] * (3 - len(nums[:3]))
+    rest = nums[3:4] or [0]
+    return tuple(base + [0 if is_beta else 1] + rest)
+
+
 @app.get("/api/public/hints")
 async def api_public_hints():
     """Holt dezente Hinweise/Updates aus einer öffentlichen GitHub-Quelle (#233).
@@ -377,7 +392,11 @@ async def api_public_hints():
         hints = data if isinstance(data, list) else data.get("hints", [])
         result["hints"] = [
             h for h in hints
-            if not h.get("min_version") or h["min_version"] <= __version__
+            if (not h.get("min_version") or h["min_version"] <= __version__)
+            # #711: Release-Hints (mit `version`-Feld) sind UPDATE-Hinweise —
+            # nur zeigen, wenn die angekuendigte Version NEUER ist als die
+            # installierte. Sonst sieht ein beta.102-User "Neu in beta.101".
+            and (not h.get("version") or _version_tuple(h["version"]) > _version_tuple(__version__))
         ]
     except Exception as exc:
         logger.debug("hints fetch failed: %s", exc)
@@ -8425,6 +8444,19 @@ async def api_run_auto_actions():
     """
     from datetime import datetime
     now = datetime.now().isoformat()
+    # #708: Engine-Steps schreiben viel — ein abgebrochener Step darf keine
+    # offene Transaktion (= dauerhaften Write-Lock fuer den MCP-Server-
+    # Writer) hinterlassen. Netz am Ende des Zyklus, siehe finally.
+    try:
+        return _run_auto_actions_inner(now)
+    finally:
+        try:
+            _db.rollback_if_stale(context="Auto-Engine-Zyklus")
+        except Exception:
+            pass
+
+
+def _run_auto_actions_inner(now: str) -> dict:
     expire_result = _run_auto_expire(now)
     fu_result = _run_auto_followup_reconciler(now)
     # v1.7.0-beta.25: Mail- + Doku-Auto-Klassifikation. Lokale AI sortiert

--- a/src/bewerbungs_assistent/database.py
+++ b/src/bewerbungs_assistent/database.py
@@ -162,7 +162,33 @@ class Database:
             self._conn.row_factory = sqlite3.Row
             self._conn.execute("PRAGMA journal_mode=WAL")
             self._conn.execute("PRAGMA foreign_keys=ON")
+            # #708: MCP-Server und Dashboard-Thread haben je eine eigene
+            # Connection (zwei Writer). Ohne busy_timeout scheitert ein Write
+            # SOFORT mit 'database is locked', sobald der andere gerade
+            # schreibt — mit Timeout wird bis zu 5s gewartet.
+            self._conn.execute("PRAGMA busy_timeout=5000")
         return self._conn
+
+    def rollback_if_stale(self, context: str = "") -> bool:
+        """#708: Sicherheitsnetz gegen geleakte Transaktionen.
+
+        Wird an Ausfuehrungs-Grenzen gerufen (Tool-Middleware, Auto-Engine-
+        Zyklus). Eine dort noch offene implizite Transaktion ist IMMER ein
+        Leak (z.B. Tool via Timeout mitten im Write abgebrochen) und wuerde
+        den Write-Lock dauerhaft halten — alle anderen Writer scheitern dann
+        bis zum Prozess-Neustart.
+        """
+        if self._conn is not None and self._conn.in_transaction:
+            try:
+                self._conn.rollback()
+                logger.warning(
+                    "Offene Transaktion nach %s zurueckgerollt (#708) — "
+                    "ein Write wurde vermutlich abgebrochen.", context or "Lauf"
+                )
+                return True
+            except Exception as exc:
+                logger.error("Rollback-Sicherheitsnetz fehlgeschlagen: %s", exc)
+        return False
 
     def close(self):
         if self._conn:
@@ -4315,8 +4341,8 @@ class Database:
                 applied_at, cover_letter_path, cv_path, notes, created_at,
                 bewerbungsart, lebenslauf_variante, ansprechpartner,
                 kontakt_email, portal_name, source,
-                description_snapshot, snapshot_date)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                description_snapshot, snapshot_date, endkunde)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (
             aid, stored_job_hash, pid, data.get("title"), data.get("company"),
             data.get("url"), data.get("status", "beworben"),
@@ -4330,6 +4356,7 @@ class Database:
             source,
             data.get("description_snapshot", ""),
             data.get("snapshot_date", ""),
+            data.get("endkunde", ""),
         ))
         # Add initial event
         conn.execute("""

--- a/src/bewerbungs_assistent/server.py
+++ b/src/bewerbungs_assistent/server.py
@@ -124,6 +124,15 @@ class HeartbeatMiddleware(Middleware):
         except Exception as e:
             logger.error("Tool %s Fehler: %s", tool_name, e, exc_info=True)
             raise
+        finally:
+            # #708: Bricht wait_for ein Tool mitten in einem Write ab (oder
+            # leakt ein Fehlerpfad eine Transaktion), bliebe der Write-Lock
+            # sonst dauerhaft offen — jeder weitere Write (auch der des
+            # Dashboard-Threads) scheitert dann bis zum Neustart.
+            try:
+                db.rollback_if_stale(context=f"Tool '{tool_name}'")
+            except Exception:
+                pass
 
 
 mcp.add_middleware(HeartbeatMiddleware())

--- a/src/bewerbungs_assistent/tools/analyse.py
+++ b/src/bewerbungs_assistent/tools/analyse.py
@@ -1099,6 +1099,35 @@ def register(mcp, db, logger):
                     "problem": "Keine Berufserfahrung hinterlegt",
                     "loesung": "position_hinzufuegen() oder Lebenslauf hochladen",
                 })
+            # #705: Integritaets-Check gegen Profil-Datenverlust. Ein
+            # GEPFLEGTES Profil (Positionen + Skills vorhanden) sollte auch
+            # Kontaktdaten und informelle Notizen haben — sind die ploetzlich
+            # leer, deutet das auf einen Datenverlust hin (z.B. den erst in
+            # beta.101 gefixten profil_erstellen-Ueberschreib-Bug).
+            if positions and len(skills) >= 3:
+                leere_kontaktfelder = [
+                    feld for feld in ("email", "phone", "address", "summary")
+                    if not (profile.get(feld) or "").strip()
+                ]
+                notizen_leer = not (profile.get("informal_notes") or "").strip()
+                if len(leere_kontaktfelder) >= 3 or (leere_kontaktfelder and notizen_leer):
+                    warnungen.append({
+                        "bereich": "Profil-Integritaet",
+                        "problem": (
+                            "Das Profil ist gepflegt (Positionen + Skills vorhanden), aber "
+                            f"{'Kontaktfelder (' + ', '.join(leere_kontaktfelder) + ')' if leere_kontaktfelder else ''}"
+                            f"{' und ' if leere_kontaktfelder and notizen_leer else ''}"
+                            f"{'die informellen Notizen' if notizen_leer else ''} sind leer — "
+                            "moeglicher Datenverlust (#705)."
+                        ),
+                        "loesung": (
+                            "Pruefe data/backups/ — vor jeder Migration wird ein Backup "
+                            "angelegt. Wiederherstellung einzelner Felder: Backup-DB oeffnen "
+                            "und Werte via profil_bearbeiten() zuruecktragen. "
+                            "Seit beta.101 ueberschreibt profil_erstellen() keine "
+                            "Bestandsfelder mehr."
+                        ),
+                    })
 
         # --- 2. Suchkriterien-Check ---
         criteria = db.get_search_criteria()

--- a/src/bewerbungs_assistent/tools/bewerbungen.py
+++ b/src/bewerbungs_assistent/tools/bewerbungen.py
@@ -300,7 +300,9 @@ def register(mcp, db, logger):
         kontakt_email: str = "",
         portal_name: str = "",
         bereits_beworben: bool = True,
-        stellenbeschreibung: str = ""
+        stellenbeschreibung: str = "",
+        endkunde: str = "",
+        force: bool = False
     ) -> dict:
         """Erstellt eine neue Bewerbung (manuell oder aus einer gefundenen Stelle).
 
@@ -325,6 +327,13 @@ def register(mcp, db, logger):
             portal_name: Name des Portals (bei bewerbungsart=ueber_portal)
             bereits_beworben: True = schon beworben (Standard), False = will mich bewerben (#170)
             stellenbeschreibung: Optional: Vollständige Stellenbeschreibung (#172) — wird automatisch gespeichert
+            endkunde: Optional (#710): Endkunde bei Vermittler-Engagements
+                (company = Vermittler). Bei gesetztem Endkunden vergleicht die
+                Duplikat-Erkennung company+endkunde statt nur company+title —
+                mehrere Engagements ueber denselben Vermittler sind dann
+                getrennt erfassbar.
+            force: True ueberstimmt die Duplikat-Erkennung bewusst (#709) —
+                nutzen wenn es wirklich eine eigene, neue Bewerbung ist.
         """
         # #170: Wenn der User sich noch nicht beworben hat → in_vorbereitung
         # #506: Aber NUR, wenn der Aufrufer keinen expliziten Status gesetzt hat.
@@ -364,13 +373,22 @@ def register(mcp, db, logger):
         # company.lower() — verfehlt z.B. "IQ ... (Endkunde: Siemens)" vs
         # "Siemens (via IQ ...)". Plus Email-/Ansprechpartner-Match als
         # zusaetzliches Signal.
-        existing_apps = db.get_applications()
+        # #709: force=True ueberspringt das Dedup-Gate bewusst (der frueher
+        # in der Fehlermeldung versprochene notes-Override war nie
+        # implementiert — jetzt gibt es den expliziten Parameter).
+        existing_apps = [] if force else db.get_applications()
         norm_company = _normalize_company_for_dedup(company)
         norm_title = _normalize_title_for_dedup(title)
         norm_email = (kontakt_email or "").lower().strip()
         norm_ansprech = (ansprechpartner or "").lower().strip()
+        norm_endkunde = (endkunde or "").lower().strip()
 
         for existing in existing_apps:
+            # #710: Verschiedene Endkunden beim selben Vermittler sind
+            # KEINE Duplikate — getrennte Engagements.
+            ex_endkunde = (existing.get("endkunde") or "").lower().strip()
+            if norm_endkunde and ex_endkunde and norm_endkunde != ex_endkunde:
+                continue
             ex_company = existing.get("company", "")
             ex_title = existing.get("title", "")
             ex_email = (existing.get("kontakt_email") or "").lower().strip()
@@ -384,7 +402,8 @@ def register(mcp, db, logger):
                     "bestehende_bewerbung_id": existing["id"][:8],
                     "nachricht": f"Es gibt bereits eine Bewerbung bei {company} für '{title}' "
                                  f"(Status: {existing.get('status', '?')}). "
-                                 "Nutze bewerbung_bearbeiten() um diese zu aktualisieren."
+                                 "Nutze bewerbung_bearbeiten() um diese zu aktualisieren — "
+                                 "oder force=True, wenn es wirklich eine neue, eigene Bewerbung ist."
                 }
 
             # 2) Fuzzy-Match: aehnliche Firma + aehnlicher Titel
@@ -411,7 +430,9 @@ def register(mcp, db, logger):
                         f"Aehnliche Bewerbung gefunden: '{ex_title}' bei {ex_company} "
                         f"(Status: {existing.get('status', '?')}). "
                         f"Vermutlich Vermittler/Endkunde-Beziehung oder Titelvariante. "
-                        f"Falls neue Bewerbung trotzdem gewuenscht: notes='Klarstellen, dass dies eine eigene Bewerbung ist'."
+                        f"Falls neue Bewerbung trotzdem gewuenscht: force=True setzen — "
+                        f"bei Vermittler-Engagements zusaetzlich endkunde='...' angeben, "
+                        f"dann unterscheidet die Duplikat-Erkennung kuenftig selbst."
                     )
                 }
 
@@ -430,7 +451,7 @@ def register(mcp, db, logger):
                     "nachricht": (
                         f"Identischer Ansprechpartner/Email + aehnlicher Titel: "
                         f"'{ex_title}' bei {ex_company} (Status: {existing.get('status', '?')}). "
-                        f"Sehr wahrscheinlich Duplikat."
+                        f"Sehr wahrscheinlich Duplikat. Falls doch eigenstaendig: force=True."
                     )
                 }
 
@@ -510,6 +531,7 @@ def register(mcp, db, logger):
             "source": source,
             "description_snapshot": snapshot_text,
             "snapshot_date": _dt_snap.now().isoformat() if snapshot_text else "",
+            "endkunde": endkunde,
         })
 
         # #231: Stelle als inaktiv markieren wenn Bewerbung erstellt

--- a/src/bewerbungs_assistent/tools/workflows.py
+++ b/src/bewerbungs_assistent/tools/workflows.py
@@ -167,9 +167,15 @@ SCHRITT 3: SUCHE STARTEN
    3. Schlage vor: „Sag mir in ein paar Minuten 'Wie laeuft meine Jobsuche?' — ich
       pruefe dann mit jobsuche_status('{{job_id}}') nach."
    4. Beende den Workflow-Schritt hier. Kein weiteres jobsuche_status() im selben Turn.
-→ Wenn das Tool ein `manuelle_quellen`-Feld mitliefert, LISTE es dem User auf und
-   erklaere ihm, dass er diese Quellen ueber Claude-in-Chrome und die jeweils
-   empfohlenen Ersatz-Tools (jobspy_linkedin/jobspy_indeed/google_jobs_url) bedienen muss.
+→ Wenn das Tool ein `manuelle_quellen`-Feld mitliefert (#704):
+   ARBEITE DIESE QUELLEN SELBST AB — OHNE NACHFRAGE — sofern Claude-in-Chrome
+   verbunden ist (waehrend die Hintergrund-Suche laeuft):
+   - LinkedIn: oeffne linkedin.com/jobs/search mit den Suchprofil-Keywords
+   - XING: oeffne xing.com/jobs/search mit den Suchprofil-Keywords
+   - StepStone / Google Jobs: nutze google_jobs_url() und oeffne die URL in Chrome
+   - Passende Treffer SOFORT mit stelle_manuell_anlegen() in PBP erfassen
+   Ist Claude-in-Chrome NICHT verbunden: liste die Quellen auf und erklaere
+   dem User den Chrome-Extension-Weg.
 
 SCHRITT 4: ERGEBNISSE SICHTEN
 → Zeige die Ergebnisse mit stellen_anzeigen()

--- a/tests/test_v17_user_test_703plus.py
+++ b/tests/test_v17_user_test_703plus.py
@@ -1,0 +1,196 @@
+"""Regressionstests fuer die User-Test-Funde 11./12.06. (beta.103):
+
+- #708 (K20): busy_timeout auf der Haupt-Connection + rollback_if_stale-Netz
+- #709/#710 (K21): force=True ueberstimmt Dedup; endkunde wird gespeichert
+  und trennt Vermittler-Engagements in der Duplikat-Erkennung
+- #711 (K22): Release-Hints nur anzeigen wenn Hint-Version > installierte
+- #705 (K23): pbp_diagnose warnt bei gepflegtem Profil mit leeren Feldern
+- #704 (K24): Workflow-Prompt weist Claude an, manuelle Quellen selbst
+  abzuarbeiten
+"""
+import asyncio
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).parent.parent
+
+
+@pytest.fixture
+def setup_env():
+    tmpdir = tempfile.mkdtemp(prefix="pbp_v17_703p_")
+    os.environ["BA_DATA_DIR"] = tmpdir
+    import importlib
+    import bewerbungs_assistent.database as _db_mod
+    importlib.reload(_db_mod)
+    from bewerbungs_assistent.database import Database
+    db = Database()
+    db.initialize()
+    db.save_profile({"name": "Test"})
+    assert str(tmpdir) in str(db.db_path), f"DB nicht isoliert: {db.db_path}"
+    yield db
+    db.close()
+    import shutil
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def _call(mcp, name, args):
+    async def _run():
+        tool = await mcp.get_tool(name)
+        res = await tool.run(args)
+        return res.structured_content if hasattr(res, "structured_content") else res
+    return asyncio.run(_run())
+
+
+def _make_mcp(db, modname):
+    from fastmcp import FastMCP
+    import importlib
+    import logging
+    mod = importlib.import_module(f"bewerbungs_assistent.tools.{modname}")
+    mcp = FastMCP("test")
+    mod.register(mcp, db, logging.getLogger("test"))
+    return mcp
+
+
+# ============= #708 / K20: DB-Lock-Haertung =============
+
+def test_708_busy_timeout_gesetzt(setup_env):
+    db = setup_env
+    conn = db.connect()
+    timeout = conn.execute("PRAGMA busy_timeout").fetchone()[0]
+    assert timeout == 5000, f"busy_timeout ist {timeout}, erwartet 5000"
+
+
+def test_708_rollback_if_stale_raeumt_leak(setup_env):
+    db = setup_env
+    conn = db.connect()
+    # Leak simulieren: Write ohne commit (implizite offene Transaktion)
+    conn.execute("UPDATE settings SET value='x' WHERE key='nonexistent'")
+    conn.execute(
+        "INSERT INTO settings (key, value) VALUES ('test_leak', '1')"
+    )
+    assert conn.in_transaction, "Setup: Transaktion sollte offen sein"
+    assert db.rollback_if_stale(context="Test") is True
+    assert not conn.in_transaction, "Transaktion muss zurueckgerollt sein"
+    # Der geleakte Insert ist weg
+    row = conn.execute("SELECT 1 FROM settings WHERE key='test_leak'").fetchone()
+    assert row is None
+
+
+def test_708_rollback_if_stale_noop_ohne_transaktion(setup_env):
+    db = setup_env
+    db.connect()
+    assert db.rollback_if_stale() is False
+
+
+# ============= #709/#710 / K21: Dedup force + endkunde =============
+
+def _neue_bewerbung(db, mcp, **kwargs):
+    args = {"title": "PLM Consultant", "company": "VirtoTech Ltd.",
+            "bereits_beworben": True}
+    args.update(kwargs)
+    return _call(mcp, "bewerbung_erstellen", args)
+
+
+def test_709_force_ueberstimmt_dedup(setup_env):
+    db = setup_env
+    mcp = _make_mcp(db, "bewerbungen")
+    r1 = _neue_bewerbung(db, mcp)
+    assert r1.get("status") != "duplikat", r1
+    # Exaktes Duplikat -> geblockt, Meldung nennt force
+    r2 = _neue_bewerbung(db, mcp)
+    assert r2.get("status") == "duplikat", r2
+    assert "force" in r2.get("nachricht", ""), r2
+    # force=True -> wird angelegt
+    r3 = _neue_bewerbung(db, mcp, force=True)
+    assert r3.get("status") != "duplikat", r3
+
+
+def test_710_endkunde_gespeichert_und_trennt(setup_env):
+    db = setup_env
+    mcp = _make_mcp(db, "bewerbungen")
+    r1 = _neue_bewerbung(db, mcp, endkunde="Rota Yokogawa")
+    assert r1.get("status") != "duplikat", r1
+    # Gleicher Vermittler + gleicher Titel, ANDERER Endkunde -> kein Duplikat
+    r2 = _neue_bewerbung(db, mcp, endkunde="PRO.FILE Assessment Kunde")
+    assert r2.get("status") != "duplikat", r2
+    # endkunde ist persistiert
+    apps = db.get_applications()
+    endkunden = sorted((a.get("endkunde") or "") for a in apps)
+    assert "Rota Yokogawa" in endkunden, endkunden
+    # Gleicher Endkunde nochmal -> Duplikat
+    r3 = _neue_bewerbung(db, mcp, endkunde="Rota Yokogawa")
+    assert r3.get("status") == "duplikat", r3
+
+
+# ============= #711 / K22: Versionsvergleich =============
+
+def test_711_version_tuple_ordnung():
+    from bewerbungs_assistent.dashboard import _version_tuple as vt
+    assert vt("1.7.0-beta.101") < vt("1.7.0-beta.102")
+    assert vt("1.7.0-beta.102") < vt("1.7.0")          # Stable > jede Beta
+    assert vt("1.7.0") < vt("1.7.1")
+    assert vt("1.6.10") < vt("1.7.0-beta.1")
+    assert not (vt("1.7.0-beta.101") > vt("1.7.0-beta.102"))
+
+
+def test_711_release_hint_nur_bei_neuerer_version(setup_env, tmp_path):
+    """Hint mit version == installierte Version wird NICHT gezeigt;
+    Hint mit hoeherer version schon."""
+    db = setup_env
+    import importlib
+    import bewerbungs_assistent.dashboard as dash
+    importlib.reload(dash)
+    dash._db = db
+    from bewerbungs_assistent import __version__
+
+    def _hints_mit(version_feld):
+        hints_file = tmp_path / "hints.json"
+        hints_file.write_text(json.dumps({"hints": [{
+            "id": "x", "title": f"Neu in {version_feld}",
+            "text": "t", "version": version_feld,
+        }]}), encoding="utf-8")
+        os.environ["PBP_HINTS_URL"] = str(hints_file)
+        if hasattr(dash.api_public_hints, "_cache"):
+            delattr(dash.api_public_hints, "_cache")
+        from fastapi.testclient import TestClient
+        client = TestClient(dash.app)
+        return client.get("/api/public/hints").json()["hints"]
+
+    try:
+        assert _hints_mit(__version__) == [], "eigener Release darf nicht angekuendigt werden"
+        assert len(_hints_mit("99.0.0")) == 1, "echtes Update muss angekuendigt werden"
+    finally:
+        os.environ.pop("PBP_HINTS_URL", None)
+        if hasattr(dash.api_public_hints, "_cache"):
+            delattr(dash.api_public_hints, "_cache")
+
+
+# ============= #705 / K23: Profil-Integritaets-Warnung =============
+
+def test_705_diagnose_warnt_bei_leeren_kontaktfeldern(setup_env):
+    db = setup_env
+    # Gepflegtes Profil (Positionen + Skills), aber Kontaktfelder leer
+    db.add_position({"title": "Consultant", "company": "X",
+                     "start_date": "2020-01"})
+    for s in ("Python", "PLM", "SAP"):
+        db.add_skill({"name": s, "level": 4, "category": "fachlich"})
+    mcp = _make_mcp(db, "analyse")
+    res = _call(mcp, "pbp_diagnose", {})
+    integ = [w for w in res.get("warnungen", [])
+             if w.get("bereich") == "Profil-Integritaet"]
+    assert integ, res.get("warnungen")
+    assert "backups" in integ[0]["loesung"].lower()
+
+
+# ============= #704 / K24: Workflow-Anweisung =============
+
+def test_704_workflow_arbeitet_manuelle_quellen_ab(setup_env):
+    db = setup_env
+    from bewerbungs_assistent.tools.workflows import _prompt_registry
+    text = _prompt_registry(db)["jobsuche_workflow"]()
+    assert "ARBEITE DIESE QUELLEN SELBST AB" in text
+    assert "stelle_manuell_anlegen" in text


### PR DESCRIPTION
Fixes aus dem laufenden Abschlusstest (11./12.06.): kritischer DB-Lock (#708, busy_timeout + Rollback-Netz), Dedup-force statt nie implementiertem notes-Override (#709), endkunde-Feld (#710), Update-Banner-Semantik (#711), Profil-Integritaets-Check (#705-Haertung), Workflow arbeitet manuelle Quellen selbst ab (#704). Suite: 1723 passed, 1 skipped. Master-Plan K20-K24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)